### PR TITLE
ASBACKUP 3.11.3

### DIFF
--- a/include/encode.h
+++ b/include/encode.h
@@ -135,6 +135,8 @@ typedef struct {
 	// The as_index_task struct populated by the aerospike_index_create_complex
 	// command which is used by aerospike_index_create_wait
 	as_index_task task;
+	// boolean ctx true if the sindex has a (not null) context
+	bool ctx;
 } index_param;
 
 /*

--- a/src/utils.c
+++ b/src/utils.c
@@ -1509,6 +1509,7 @@ parse_index_info(char *ns, char *index_str, index_param *index)
 	index->set = NULL;
 	index->name = NULL;
 	index->type = INDEX_TYPE_INVALID;
+	index->ctx = false;
 	as_vector_init(&index->path_vec, sizeof (path_param), 25);
 
 	char *path = NULL;
@@ -1564,8 +1565,10 @@ parse_index_info(char *ns, char *index_str, index_param *index)
 				err("Invalid index type %s", arg);
 				goto cleanup2;
 			}
-		} else if (strcmp(para, "path") == 0 || strcmp(para, "context") == 0) {
+		} else if (strcmp(para, "bin") == 0) {
 			path = arg;
+		} else if (strcmp(para, "context") == 0 && strcasecmp(arg, "NULL") != 0) {
+			index->ctx = true;
 		}
 
 		if (path != NULL && type != PATH_TYPE_INVALID) {


### PR DESCRIPTION
[TOOLS-2021] (ASBACKUP)- [Warn and skip backing up secondary indexes with context.]


[TOOLS-2021]: https://aerospike.atlassian.net/browse/TOOLS-2021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ