### PR TITLE
asbackup 3.13.1 [TOOLS-2263] unable to restore backup file from pre 3.12.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ TSO_LIB := $(DIR_TSO)/tso.so
 
 CC ?= cc
 
-DWARF := $(shell $(CC) -Wall -Wextra -g -O0 -o /tmp/asflags_$${$$} src/flags.c; \
+DWARF := $(shell $(CC) -Wall -Wextra -O2 -o /tmp/asflags_$${$$} src/flags.c; \
 		/tmp/asflags_$${$$}; rm /tmp/asflags_$${$$})
 CFLAGS += -std=gnu99 $(DWARF) -O2 -fno-common -fno-strict-aliasing \
 		-Wall -Wextra -Wconversion -Wsign-conversion -Wmissing-declarations \

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ TSO_LIB := $(DIR_TSO)/tso.so
 
 CC ?= cc
 
-DWARF := $(shell $(CC) -Wall -Wextra -O2 -o /tmp/asflags_$${$$} src/flags.c; \
+DWARF := $(shell $(CC) -Wall -Wextra -g -O0 -o /tmp/asflags_$${$$} src/flags.c; \
 		/tmp/asflags_$${$$}; rm /tmp/asflags_$${$$})
 CFLAGS += -std=gnu99 $(DWARF) -O2 -fno-common -fno-strict-aliasing \
 		-Wall -Wextra -Wconversion -Wsign-conversion -Wmissing-declarations \

--- a/src/dec_text.c
+++ b/src/dec_text.c
@@ -1548,11 +1548,17 @@ text_parse_index(io_read_proxy_t *fd, as_vector *ns_vec, uint32_t *line_no,
 			goto cleanup3;
 		}
 
-		if (!expect_char(fd, line_no, col_no, ' ')) {
+		if (i != n_paths - 1 && !expect_char(fd, line_no, col_no, ' ')) {
 			goto cleanup3;
 		}
 
 		as_vector_append(&index->path_vec, &path);
+	}
+
+	if (peek_char(fd, line_no, col_no) != (int) '\n') {
+		if (!expect_char(fd, line_no, col_no, ' ')) {
+			goto cleanup3;
+		}
 	}
 
 	if (!text_nul_read_token(fd, false, line_no, col_no, ctx, sizeof ctx, "\n")) {

--- a/src/dec_text.c
+++ b/src/dec_text.c
@@ -1560,7 +1560,7 @@ text_parse_index(io_read_proxy_t *fd, as_vector *ns_vec, uint32_t *line_no,
 		as_vector_append(&index->path_vec, &path);
 	}
 
-	// If this is asbackup 3.12.0 (has whitespace after final path spec)
+	// If this is asbackup 3.12.0 or greater and sindex has a ctx then consume the delim
 	// then consume the extra whitespace.
 	if (peek_char(fd, line_no, col_no) != (int) '\n') {
 		if (!expect_char(fd, line_no, col_no, ' ')) {

--- a/src/dec_text.c
+++ b/src/dec_text.c
@@ -1510,7 +1510,7 @@ text_parse_index(io_read_proxy_t *fd, as_vector *ns_vec, uint32_t *line_no,
 
 	// This loop parses n_path path specs from sindex entries in the
 	// backup file. These include the space after n_paths to the path type.
-	// The code supports multiple path specs, but currently there is only ever one.
+	// The code supports multiple path specs, but there is only ever one.
 	for (size_t i = 0; i < n_paths; ++i) {
 		if (!expect_char(fd, line_no, col_no, ' ')) {
 			goto cleanup2;
@@ -1560,12 +1560,9 @@ text_parse_index(io_read_proxy_t *fd, as_vector *ns_vec, uint32_t *line_no,
 		as_vector_append(&index->path_vec, &path);
 	}
 
-	// If this is a pre asbackup 3.12.0 (has not whitespace after final path spec)
-	// then leave the newline to delimit the ctx. 
+	// If this is asbackup 3.12.0 (has whitespace after final path spec)
+	// then consume the extra whitespace.
 	if (peek_char(fd, line_no, col_no) != (int) '\n') {
-		// If there is no newline, the character must be a whitespace
-		// from asbackup 3.12.0 or greater. Consume it, the next character
-		// should be a newline or start of ctx.
 		if (!expect_char(fd, line_no, col_no, ' ')) {
 			goto cleanup3;
 		}

--- a/src/enc_text.c
+++ b/src/enc_text.c
@@ -515,11 +515,14 @@ text_put_secondary_index(io_write_proxy_t *fd,
 			return false;
 		}
 	}
-	
-	if (io_proxy_printf(fd, " %s", index->ctx != NULL ? escape(index->ctx) : "") < 0) {
-		err("Error while writing secondary index to backup file [3]");
-		return false;
+
+	if (index->ctx != NULL) {
+		if (io_proxy_printf(fd, " %s", escape(index->ctx)) < 0) {
+			err("Error while writing secondary index to backup file [3]");
+			return false;
+		}
 	}
+	
 
 	if (io_proxy_printf(fd, "\n") < 0) {
 		err("Error while writing secondary index to backup file [4]");

--- a/src/enc_text.c
+++ b/src/enc_text.c
@@ -522,7 +522,6 @@ text_put_secondary_index(io_write_proxy_t *fd,
 			return false;
 		}
 	}
-	
 
 	if (io_proxy_printf(fd, "\n") < 0) {
 		err("Error while writing secondary index to backup file [4]");


### PR DESCRIPTION
Fix interpretation of older backup file sindexs that don't append a space.