### PR TITLE
Auto draft release

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,43 @@
+---
+name: "Draft Release"
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  draft-release-notes:
+    needs: build-asbackup-mac
+    runs-on: ubuntu-latest
+    name: Draft Release
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Get Latest Tag
+      run: |
+        LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+        echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+    # below steps are for downloading release artifacts
+    - name: Download Asbackup Mac Artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: darwin-X64-macOS-11-asbackup-static
+        path: artifacts
+    - name: Download Asrestore Mac Artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: darwin-X64-macOS-11-asrestore-static
+        path: artifacts
+    # finally create the release and upload artifacts
+    - name: Upload Artifacts to Release Draft
+      uses: "softprops/action-gh-release@v1"
+      with:
+        draft: true
+        generate_release_notes: true
+        files: |
+          artifacts/*
+  # workflows to pull release artifacts from
+  build-asbackup-mac:
+    uses: aerospike/aerospike-tools-backup/.github/workflows/mac-artifact.yml@auto-draft-release

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -17,3 +17,4 @@ jobs:
       with:
         draft: true
         generate_release_notes: true
+        

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - "*"
   push:
-    tags:
+    branches:
       - "auto-draft-release"
 
 jobs:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -5,39 +5,18 @@ on:
   push:
     tags:
       - "*"
+  push:
+    tags:
+      - "auto-draft-release"
 
 jobs:
   draft-release-notes:
-    needs: build-asbackup-mac
     runs-on: ubuntu-latest
     name: Draft Release
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Get Latest Tag
-      run: |
-        LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
-        echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
-    # below steps are for downloading release artifacts
-    - name: Download Asbackup Mac Artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: darwin-X64-macOS-11-asbackup-static
-        path: artifacts
-    - name: Download Asrestore Mac Artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: darwin-X64-macOS-11-asrestore-static
-        path: artifacts
-    # finally create the release and upload artifacts
     - name: Upload Artifacts to Release Draft
       uses: "softprops/action-gh-release@v1"
       with:
         draft: true
         generate_release_notes: true
-        files: |
-          artifacts/*
-  # workflows to pull release artifacts from
-  build-asbackup-mac:
-    uses: aerospike/aerospike-tools-backup/.github/workflows/mac-artifact.yml@auto-draft-release

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -5,9 +5,8 @@ on:
   push:
     tags:
       - "*"
-  push:
     branches:
-      - "auto-draft-release"
+      - auto-draft-release
 
 jobs:
   draft-release-notes:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -5,8 +5,6 @@ on:
   push:
     tags:
       - "*"
-    branches:
-      - auto-draft-release
 
 jobs:
   draft-release-notes:


### PR DESCRIPTION
The diff is larger than it should be because I have included https://github.com/aerospike/aerospike-tools-backup/pull/48 to make sure the mac build passes. Please review that first.

Relates to TOOLS-2305 in order to record snyk reports with releases (not done here).

Example of what the draft will look like. I'm hoping more will show up in the diff section of an actual release, that might require some tweaking.
<img width="1216" alt="image" src="https://user-images.githubusercontent.com/53876192/214387787-abd261a3-a655-4699-bf21-9d58e219e2b3.png">

I'm hoping to spread this to other repos.
Will squash merge and discard all the garbage messages.