### PR TITLE
fix: tools-2624 correctly set bin-list for each thread

### DIFF
--- a/src/backup.c
+++ b/src/backup.c
@@ -2255,12 +2255,12 @@ init_scan_bins(char *bin_list, as_scan *scan)
 	as_vector bin_vec;
 	as_vector_inita(&bin_vec, sizeof (void *), 25);
 
-	if (bin_list[0] == 0) {
+	if (clone[0] == 0) {
 		err("Empty bin list");
 		goto cleanup1;
 	}
 
-	split_string(bin_list, ',', true, &bin_vec);
+	split_string(clone, ',', true, &bin_vec);
 
 	as_scan_select_init(scan, (uint16_t)bin_vec.size);
 

--- a/test/integration/test_filter.py
+++ b/test/integration/test_filter.py
@@ -248,6 +248,24 @@ def test_restore_bin_list():
 		restore_delay=1
 	)
 
+def test_backup_bin_list():
+	"""
+	Tests the --bin-list backup option with --parallel.
+	Regression for tools-2624.
+	"""
+	backup_and_restore(
+		put_data,
+		None,
+		lambda context: check_data(context,
+			True, True, True,
+			True, True,
+			True, True, True,
+			True),
+		backup_opts=["--bin-list", "%s,%s" % (BIN_NAME_1, BIN_NAME_2)],
+		restore_opts=["--wait"],
+		restore_delay=1
+	)
+
 def test_backup_no_records():
 	"""
 	Tests the --no-records backup option.

--- a/test/integration/test_filter.py
+++ b/test/integration/test_filter.py
@@ -248,7 +248,7 @@ def test_restore_bin_list():
 		restore_delay=1
 	)
 
-def test_backup_bin_list():
+def test_backup_bin_list_parallel():
 	"""
 	Tests the --bin-list backup option with --parallel.
 	Regression for tools-2624.


### PR DESCRIPTION
split_string() was being called on the same bin_list string from each thread, mangling it and providing a different bin_list for each thread.