### PR TITLE
Tools 2804

### DIFF
--- a/include/backup_config.h
+++ b/include/backup_config.h
@@ -197,7 +197,7 @@ typedef struct backup_config {
  * The backup_config_t struct returned by this method is always destroyable (and
  * should be destroyed) regardless of the return value
  */
-int backup_config_init(int argc, char* argv[], backup_config_t* conf);
+int backup_config_set(int argc, char* argv[], backup_config_t* conf);
 
 /*
  * Validates the backup config, checking for mutually exclusive options,
@@ -207,7 +207,18 @@ int backup_config_init(int argc, char* argv[], backup_config_t* conf);
  */
 int backup_config_validate(backup_config_t* conf);
 
-void backup_config_default(backup_config_t* conf);
+/* backup_config_set_defaults sets conf fields that are heap allocated
+ * to their default value. This is used internally to allow users of the shared library
+ * this function should be called after backup_config_init and before backup_config_set
+ * to set their conf values without leaking the heap allocated default values
+ */
+void backup_config_set_heap_defaults(backup_config_t *conf);
+
+/*
+ * backup_config_init initializes all conf fields to their
+ * zero value or a default value.
+ */
+void backup_config_init(backup_config_t* conf);
 
 void backup_config_destroy(backup_config_t* conf);
 

--- a/include/conf.h
+++ b/include/conf.h
@@ -39,7 +39,7 @@ extern "C" {
 // Globals.
 //
 
-extern char *DEFAULTPASSWORD;
+extern char *DEFAULT_PASSWORD;
 
 
 //==========================================================

--- a/include/restore_config.h
+++ b/include/restore_config.h
@@ -188,7 +188,7 @@ typedef struct restore_config {
  * The restore_config_t struct returned by this method is always destroyable (and
  * should be destroyed) regardless of the return value
  */
-int restore_config_init(int argc, char* argv[], restore_config_t* conf);
+int restore_config_set(int argc, char* argv[], restore_config_t* conf);
 
 /*
  * Validates the restore config, checking for mutually exclusive options,
@@ -198,7 +198,18 @@ int restore_config_init(int argc, char* argv[], restore_config_t* conf);
  */
 int restore_config_validate(restore_config_t *conf);
 
-void restore_config_default(restore_config_t* conf);
+/* restore_config_set_defaults sets conf fields that are heap allocated
+ * to their default value. This is used internally to allow users of the shared library
+ * this function should be called after restore_config_init and before restore_config_set
+ * to set their conf values without leaking the heap allocated default values
+ */
+void restore_config_set_heap_defaults(restore_config_t *conf);
+
+/*
+ * restore_config_init initializes all conf fields to their
+ * zero value or a default value.
+ */
+void restore_config_init(restore_config_t* conf);
 
 void restore_config_destroy(restore_config_t* conf);
 

--- a/src/backup.c
+++ b/src/backup.c
@@ -209,7 +209,7 @@ backup_main(int32_t argc, char **argv)
 
 	backup_config_t conf;
 
-	int backup_config_res = backup_config_init(argc, argv, &conf);
+	int backup_config_res = backup_config_set(argc, argv, &conf);
 	if (backup_config_res != 0) {
 		if (backup_config_res == BACKUP_CONFIG_INIT_EXIT) {
 			res = EXIT_SUCCESS;
@@ -259,6 +259,7 @@ backup_status_t*
 backup_run(backup_config_t* conf) {
 	as_vector_init(&g_globals, sizeof(backup_globals_t), 1);
 
+	backup_config_set_heap_defaults(conf);
 	backup_status_t* status = start_backup(conf);
 
 	file_proxy_cloud_shutdown();

--- a/src/backup_config.c
+++ b/src/backup_config.c
@@ -163,6 +163,7 @@ backup_config_set(int argc, char* argv[], backup_config_t* conf)
 	};
 
 	backup_config_init(conf);
+	backup_config_set_heap_defaults(conf);
 
 	int32_t opt;
 	int64_t tmp;

--- a/src/backup_config.c
+++ b/src/backup_config.c
@@ -49,7 +49,7 @@ static void usage(const char *name);
 //
 
 int
-backup_config_init(int argc, char* argv[], backup_config_t* conf)
+backup_config_set(int argc, char* argv[], backup_config_t* conf)
 {
 	static struct option options[] = {
 
@@ -162,7 +162,7 @@ backup_config_init(int argc, char* argv[], backup_config_t* conf)
 		{ NULL, 0, NULL, 0 }
 	};
 
-	backup_config_default(conf);
+	backup_config_init(conf);
 
 	int32_t opt;
 	int64_t tmp;
@@ -377,7 +377,7 @@ backup_config_init(int argc, char* argv[], backup_config_t* conf)
 					// No password specified should
 					// force it to default password
 					// to trigger prompt.
-					conf->password = safe_strdup(DEFAULTPASSWORD);
+					conf->password = safe_strdup(DEFAULT_PASSWORD);
 				}
 			}
 			break;
@@ -665,7 +665,7 @@ backup_config_init(int argc, char* argv[], backup_config_t* conf)
 				} else {
 					// No password specified should force it to default password
 					// to trigger prompt.
-					conf->tls.keyfile_pw = safe_strdup(DEFAULTPASSWORD);
+					conf->tls.keyfile_pw = safe_strdup(DEFAULT_PASSWORD);
 				}
 			}
 			break;
@@ -820,10 +820,6 @@ backup_config_validate(backup_config_t* conf)
 		conf->port = DEFAULT_PORT;
 	}
 
-	if (conf->host == NULL) {
-		conf->host = safe_strdup(DEFAULT_HOST);
-	}
-
 	if (conf->ns[0] == 0 && !conf->remove_artifacts) {
 		err("Please specify a namespace (-n option)");
 		return BACKUP_CONFIG_VALIDATE_FAILURE;
@@ -923,13 +919,32 @@ backup_config_validate(backup_config_t* conf)
 }
 
 void
-backup_config_default(backup_config_t* conf)
+backup_config_set_heap_defaults(backup_config_t* conf) {
+	if (conf->host == NULL) {
+		conf->host = safe_strdup(DEFAULT_HOST);
+	}
+	
+	if (conf->password == NULL) {
+		conf->password = safe_strdup(DEFAULT_PASSWORD);
+	}
+
+	if (conf->secret_cfg.addr == NULL) {
+		conf->secret_cfg.addr = safe_strdup(DEFAULT_SECRET_AGENT_HOST);
+	}
+
+	if (conf->secret_cfg.port == NULL) {
+		conf->secret_cfg.port = safe_strdup(DEFAULT_SECRET_AGENT_PORT);
+	}
+}
+
+void
+backup_config_init(backup_config_t* conf)
 {
 	conf->host = NULL;
 	conf->port = -1;
 	conf->use_services_alternate = false;
 	conf->user = NULL;
-	conf->password = safe_strdup(DEFAULTPASSWORD);
+	conf->password = NULL;
 	conf->auth_mode = NULL;
 
 	conf->s3_region = NULL;
@@ -988,8 +1003,6 @@ backup_config_default(backup_config_t* conf)
 	conf->retry_delay = 0;
 
 	sa_cfg_init(&conf->secret_cfg);
-	conf->secret_cfg.addr = safe_strdup(DEFAULT_SECRET_AGENT_HOST);
-	conf->secret_cfg.port = safe_strdup(DEFAULT_SECRET_AGENT_PORT);
 }
 
 void

--- a/src/backup_status.c
+++ b/src/backup_status.c
@@ -319,7 +319,7 @@ backup_status_init(backup_status_t* status, backup_config_t* conf)
 
 	char* password;
 	if (conf->user) {
-		if (strcmp(conf->password, DEFAULTPASSWORD) == 0) {
+		if (strcmp(conf->password, DEFAULT_PASSWORD) == 0) {
 			password = getpass("Enter Password: ");
 		}
 		else {
@@ -334,7 +334,7 @@ backup_status_init(backup_status_t* status, backup_config_t* conf)
 
 	if (conf->tls.keyfile && conf->tls.keyfile_pw) {
 		char* tls_keyfile_pw;
-		if (strcmp(conf->tls.keyfile_pw, DEFAULTPASSWORD) == 0) {
+		if (strcmp(conf->tls.keyfile_pw, DEFAULT_PASSWORD) == 0) {
 			tls_keyfile_pw = getpass("Enter TLS-Keyfile Password: ");
 		}
 		else {

--- a/src/conf.c
+++ b/src/conf.c
@@ -59,7 +59,7 @@
 // Globals.
 //
 
-char *DEFAULTPASSWORD = "SomeDefaultRandomPassword";
+char *DEFAULT_PASSWORD = "SomeDefaultRandomPassword";
 
 
 //=========================================================

--- a/src/conf.c
+++ b/src/conf.c
@@ -124,6 +124,8 @@ config_from_file(void *c, const char *instance, const char *fname,
 
 		if (is_backup) {
 
+			backup_config_set_heap_defaults((backup_config_t*)c);
+
 			sa_cfg* secret_cfg = &((backup_config_t*)c)->secret_cfg;
 			if (! config_secret_agent(config_table, secret_cfg, instance, errbuf)) {
 				status = false;
@@ -140,6 +142,8 @@ config_from_file(void *c, const char *instance, const char *fname,
 				status = false;
 			}
 		} else {
+
+			restore_config_set_heap_defaults((restore_config_t*)c);
 
 			sa_cfg* secret_cfg = &((restore_config_t*)c)->secret_cfg;
 			if (! config_secret_agent(config_table, secret_cfg, instance, errbuf)) {

--- a/src/restore.c
+++ b/src/restore.c
@@ -83,7 +83,7 @@ restore_main(int32_t argc, char **argv)
 
 	restore_config_t conf;
 
-	int restore_config_res = restore_config_init(argc, argv, &conf);
+	int restore_config_res = restore_config_set(argc, argv, &conf);
 	if (restore_config_res != 0) {
 		if (restore_config_res == RESTORE_CONFIG_INIT_EXIT) {
 			res = EXIT_SUCCESS;
@@ -129,6 +129,7 @@ cleanup:
  */
 restore_status_t*
 restore_run(restore_config_t *conf) {
+	restore_config_set_heap_defaults(conf);
 	restore_status_t *status = start_restore(conf);
 	file_proxy_cloud_shutdown();
 

--- a/src/restore_config.c
+++ b/src/restore_config.c
@@ -50,7 +50,7 @@ static void usage(const char* name);
 //
 
 int
-restore_config_init(int argc, char* argv[], restore_config_t* conf)
+restore_config_set(int argc, char* argv[], restore_config_t* conf)
 {
 	static struct option options[] = {
 
@@ -159,7 +159,8 @@ restore_config_init(int argc, char* argv[], restore_config_t* conf)
 		{ NULL, 0, NULL, 0 }
 	};
 
-	restore_config_default(conf);
+	restore_config_init(conf);
+	restore_config_set_heap_defaults(conf);
 
 	int32_t optcase;
 	int64_t tmp;
@@ -374,7 +375,7 @@ restore_config_init(int argc, char* argv[], restore_config_t* conf)
 					// No password specified should
 					// force it to default password
 					// to trigger prompt.
-					conf->password = safe_strdup(DEFAULTPASSWORD);
+					conf->password = safe_strdup(DEFAULT_PASSWORD);
 				}
 			}
 			break;
@@ -612,7 +613,7 @@ restore_config_init(int argc, char* argv[], restore_config_t* conf)
 					// No password specified should
 					// force it to default password
 					// to trigger prompt.
-					conf->tls.keyfile_pw = safe_strdup(DEFAULTPASSWORD);
+					conf->tls.keyfile_pw = safe_strdup(DEFAULT_PASSWORD);
 				}
 			}
 			break;
@@ -846,13 +847,34 @@ restore_config_validate(restore_config_t *conf) {
 }
 
 void
-restore_config_default(restore_config_t *conf)
+restore_config_set_heap_defaults(restore_config_t *conf) {
+	if (conf->host == NULL) {
+		conf->host = safe_strdup(DEFAULT_HOST);
+	}
+	
+	if (conf->password == NULL) {
+		conf->password = safe_strdup(DEFAULT_PASSWORD);
+	}
+
+	if (conf->secret_cfg.addr == NULL) {
+		conf->secret_cfg.addr = safe_strdup(DEFAULT_SECRET_AGENT_HOST);
+	}
+
+	if (conf->secret_cfg.port == NULL) {
+		conf->secret_cfg.port = safe_strdup(DEFAULT_SECRET_AGENT_PORT);
+	}
+}
+
+void
+restore_config_init(restore_config_t *conf)
 {
-	conf->host = safe_strdup(DEFAULT_HOST);
+	memset(conf, 0, sizeof(restore_config_t));
+
+	conf->host = NULL;
 	conf->use_services_alternate = false;
 	conf->port = DEFAULT_PORT;
 	conf->user = NULL;
-	conf->password = safe_strdup(DEFAULTPASSWORD);
+	conf->password = NULL;
 	conf->auth_mode = NULL;
 
 	conf->s3_region = NULL;
@@ -904,8 +926,6 @@ restore_config_default(restore_config_t *conf)
 	conf->tls_name = NULL;
 
 	sa_cfg_init(&conf->secret_cfg);
-	conf->secret_cfg.addr = safe_strdup(DEFAULT_SECRET_AGENT_HOST);
-	conf->secret_cfg.port = safe_strdup(DEFAULT_SECRET_AGENT_PORT);
 }
 
 void

--- a/src/restore_status.c
+++ b/src/restore_status.c
@@ -425,7 +425,7 @@ _init_as_config(as_config* as_conf, const restore_config_t* conf,
 
 	char* password;
 	if (conf->user) {
-		if (strcmp(conf->password, DEFAULTPASSWORD) == 0) {
+		if (strcmp(conf->password, DEFAULT_PASSWORD) == 0) {
 			password = getpass("Enter Password: ");
 		}
 		else {
@@ -443,7 +443,7 @@ _init_as_config(as_config* as_conf, const restore_config_t* conf,
 	}
 	else if (conf->tls.keyfile && conf->tls.keyfile_pw) {
 		char* keyfile_pw;
-		if (strcmp(conf->tls.keyfile_pw, DEFAULTPASSWORD) == 0) {
+		if (strcmp(conf->tls.keyfile_pw, DEFAULT_PASSWORD) == 0) {
 			keyfile_pw = getpass("Enter TLS-Keyfile Password: ");
 		}
 		else {

--- a/src/restore_status.c
+++ b/src/restore_status.c
@@ -157,16 +157,25 @@ restore_status_init(restore_status_t* status, const restore_config_t* conf)
 	info_as = (aerospike*) cf_malloc(sizeof(aerospike));
 	aerospike_init(info_as, &info_as_conf);
 
+#if AS_EVENT_LIB_DEFINED
+	if (!as_event_create_loops(conf->event_loops)) {
+		err("Failed to create %d event loop(s)", conf->event_loops);
+		goto cleanup3;
+	}
+#else
+#error "Must define an event library when building"
+#endif
+
 	ver("Connecting to cluster");
 
 	if (aerospike_connect(info_as, &ae) != AEROSPIKE_OK) {
 		err("Error while connecting to %s:%d - code %d: %s at %s:%d",
 				conf->host, conf->port, ae.code, ae.message, ae.file, ae.line);
-		goto cleanup3;
+		goto cleanup4;
 	}
 
 	if (get_server_version(info_as, &status->version_info) != 0) {
-		goto cleanup4;
+		goto cleanup5;
 	}
 
 	ver("Connected to server version %u.%u.%u.%u",
@@ -180,7 +189,7 @@ restore_status_init(restore_status_t* status, const restore_config_t* conf)
 	}
 	else if (!server_has_batch_writes(info_as, &status->version_info,
 				&status->batch_writes_enabled)) {
-		goto cleanup4;
+		goto cleanup5;
 	}
 
 	if (conf->batch_size == BATCH_SIZE_UNDEFINED) {
@@ -196,19 +205,19 @@ restore_status_init(restore_status_t* status, const restore_config_t* conf)
 	}
 
 	if (!set_resource_limit(conf, status->batch_size, status->batch_writes_enabled)) {
-		goto cleanup4;
+		goto cleanup5;
 	}
 
 	if (SERVER_VERSION_BEFORE(&status->version_info, 4, 9)) {
 		err("Aerospike Server version 4.9 or greater is required to run "
 				"asrestore, but version %" PRIu32 ".%" PRIu32 " is in use.",
 				status->version_info.major, status->version_info.minor);
-		goto cleanup4;
+		goto cleanup5;
 	}
 
 	as_config as_conf;
 	if (!_init_as_config(&as_conf, conf, &info_as_conf)) {
-		goto cleanup4;
+		goto cleanup5;
 	}
 
 	if (status->batch_writes_enabled) {
@@ -226,15 +235,6 @@ restore_status_init(restore_status_t* status, const restore_config_t* conf)
 
 	status->as = cf_malloc(sizeof(aerospike));
 	aerospike_init(status->as, &as_conf);
-
-#if AS_EVENT_LIB_DEFINED
-	if (!as_event_create_loops(conf->event_loops)) {
-		err("Failed to create %d event loop(s)", conf->event_loops);
-		goto cleanup5;
-	}
-#else
-#error "Must define an event library when building"
-#endif
 
 	if (aerospike_connect(status->as, &ae) != AEROSPIKE_OK) {
 		err("Error while connecting to %s:%d - code %d: %s at %s:%d",
@@ -256,16 +256,16 @@ cleanup7:
 	aerospike_close(status->as, &ae);
 
 cleanup6:
-	as_event_close_loops();
-
-cleanup5:
 	aerospike_destroy(status->as);
 	cf_free(status->as);
 
-cleanup4:
+cleanup5:
 	if (info_as != NULL) {
 		aerospike_close(info_as, &ae);
 	}
+
+cleanup4:
+	as_event_close_loops();
 
 cleanup3:
 	if (info_as != NULL) {

--- a/test/integration/test_secrets.py
+++ b/test/integration/test_secrets.py
@@ -489,14 +489,14 @@ def setup_function(function):
     os.system("rm -rf " + SA_RSRC_PATH)
     os.system("mkdir " + SA_RSRC_PATH)
 
-def test_restore_config_init():
+def test_restore_config_set():
 	exp_argc, exp_argv = gen_args(RESTORE_SECRET_OPTIONS, "asrestore")
 	
 	expected_conf = RestoreConfigT()
 	p_exp_conf = ctypes.POINTER(RestoreConfigT)(expected_conf)
 	c_exp_argv = (ctypes.c_char_p * exp_argc)(*exp_argv)
 	p_exp_argv = ctypes.POINTER(ctypes.c_char_p)(c_exp_argv)
-	restore_so.restore_config_init(exp_argc, p_exp_argv, p_exp_conf)
+	restore_so.restore_config_set(exp_argc, p_exp_argv, p_exp_conf)
 
 	# configs that don't use secrets for these fields will fill
 	# the ~file fields instead of the ~string fields
@@ -528,7 +528,7 @@ def test_restore_config_init():
 	agent = sa.get_secret_agent(config=SA_CONF_PATH)
 	try:
 		agent.start()
-		restore_so.restore_config_init(argc, p_argv, p_conf)
+		restore_so.restore_config_set(argc, p_argv, p_conf)
 	except Exception as e:
 		raise e
 	finally:
@@ -540,14 +540,14 @@ def test_restore_config_init():
 
 	assert expected_conf == conf
 
-def test_backup_config_init():
+def test_backup_config_set():
 	exp_argc, exp_argv = gen_args(BACKUP_SECRET_OPTIONS, "asbackup")
 
 	expected_conf = BackupConfigT()
 	p_exp_conf = ctypes.POINTER(BackupConfigT)(expected_conf)
 	c_exp_argv = (ctypes.c_char_p * exp_argc)(*exp_argv)
 	p_exp_argv = ctypes.POINTER(ctypes.c_char_p)(c_exp_argv)
-	backup_so.backup_config_init(exp_argc, p_exp_argv, p_exp_conf)
+	backup_so.backup_config_set(exp_argc, p_exp_argv, p_exp_conf)
 
 	# configs that don't use secrets for these fields will file
 	# the ~file fields instead of the ~string fields
@@ -579,7 +579,7 @@ def test_backup_config_init():
 	agent = sa.get_secret_agent(config=SA_CONF_PATH)
 	try:
 		agent.start()
-		backup_so.backup_config_init(argc, p_argv, p_conf)
+		backup_so.backup_config_set(argc, p_argv, p_conf)
 	except Exception as e:
 		raise e
 	finally:
@@ -598,7 +598,7 @@ def test_backup_conf_file():
 	p_exp_conf = ctypes.POINTER(BackupConfigT)(expected_conf)
 	c_exp_argv = (ctypes.c_char_p * exp_argc)(*exp_argv)
 	p_exp_argv = ctypes.POINTER(ctypes.c_char_p)(c_exp_argv)
-	backup_so.backup_config_init(exp_argc, p_exp_argv, p_exp_conf)
+	backup_so.backup_config_set(exp_argc, p_exp_argv, p_exp_conf)
 
 	# configs that don't use secrets for these fields will fill
 	# the ~file fields instead of the ~string fields
@@ -647,7 +647,7 @@ def test_asrestore_conf_file():
 	p_exp_conf = ctypes.POINTER(RestoreConfigT)(expected_conf)
 	c_exp_argv = (ctypes.c_char_p * exp_argc)(*exp_argv)
 	p_exp_argv = ctypes.POINTER(ctypes.c_char_p)(c_exp_argv)
-	restore_so.restore_config_init(exp_argc, p_exp_argv, p_exp_conf)
+	restore_so.restore_config_set(exp_argc, p_exp_argv, p_exp_conf)
 
 	# configs that don't use secrets for these fields will fill
 	# the ~file fields instead of the ~string fields

--- a/test/integration/test_secrets.py
+++ b/test/integration/test_secrets.py
@@ -623,7 +623,7 @@ def test_backup_conf_file():
 
 	conf = BackupConfigT()
 	p_conf = ctypes.POINTER(BackupConfigT)(conf)
-	backup_so.backup_config_default(p_conf)
+	backup_so.backup_config_init(p_conf)
 
 	agent = sa.get_secret_agent(config=SA_CONF_PATH)
 	try:
@@ -672,7 +672,7 @@ def test_asrestore_conf_file():
 
 	conf = RestoreConfigT()
 	p_conf = ctypes.POINTER(RestoreConfigT)(conf)
-	restore_so.restore_config_default(p_conf)
+	restore_so.restore_config_init(p_conf)
 
 	agent = sa.get_secret_agent(config=SA_CONF_PATH)
 	try:

--- a/test/unit/test_backup_conf.c
+++ b/test/unit/test_backup_conf.c
@@ -163,8 +163,8 @@ START_TEST(test_init_empty)
 	tmp_file_init("", "", "", "");
 	backup_config_t c1;
 	backup_config_t c2;
-	backup_config_default(&c1);
-	backup_config_default(&c2);
+	backup_config_init(&c1);
+	backup_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -181,8 +181,8 @@ START_TEST(test_name) \
 	tmp_file_init(str_name "=true\n", "", "", ""); \
 	backup_config_t c1; \
 	backup_config_t c2; \
-	backup_config_default(&c1); \
-	backup_config_default(&c2); \
+	backup_config_init(&c1); \
+	backup_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	c2.field_name = true; \
@@ -203,8 +203,8 @@ START_TEST(test_name) \
 	tmp_file_init(str_name "=314159\n", "", "", ""); \
 	backup_config_t c1; \
 	backup_config_t c2; \
-	backup_config_default(&c1); \
-	backup_config_default(&c2); \
+	backup_config_init(&c1); \
+	backup_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	c2.field_name = 314159lu * (mult); \
@@ -224,8 +224,8 @@ START_TEST(test_name) \
 	tmp_file_init(str_name "=\"" str_val "\"\n", "", "", ""); \
 	backup_config_t c1; \
 	backup_config_t c2; \
-	backup_config_default(&c1); \
-	backup_config_default(&c2); \
+	backup_config_init(&c1); \
+	backup_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	cf_free(c2.field_name); \
@@ -243,8 +243,8 @@ START_TEST(test_name) \
 	tmp_file_init("", "", "", str_name "=\"" str_val "\"\n"); \
 	backup_config_t c1; \
 	backup_config_t c2; \
-	backup_config_default(&c1); \
-	backup_config_default(&c2); \
+	backup_config_init(&c1); \
+	backup_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	cf_free((void*)c2.field_name); \
@@ -262,8 +262,8 @@ START_TEST(test_name) \
 	tmp_file_init("", "", "", str_name "=314159\n"); \
 	backup_config_t c1; \
 	backup_config_t c2; \
-	backup_config_default(&c1); \
-	backup_config_default(&c2); \
+	backup_config_init(&c1); \
+	backup_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	c2.field_name = 314159lu; \
@@ -311,8 +311,8 @@ START_TEST(test_init_set_list_single)
 	tmp_file_init("", "set=\"set-1\"", "", "");
 	backup_config_t c1;
 	backup_config_t c2;
-	backup_config_default(&c1);
-	backup_config_default(&c2);
+	backup_config_init(&c1);
+	backup_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -330,8 +330,8 @@ START_TEST(test_init_set_list)
 	tmp_file_init("", "set=\"set-1,set-2,set-3\"", "", "");
 	backup_config_t c1;
 	backup_config_t c2;
-	backup_config_default(&c1);
-	backup_config_default(&c2);
+	backup_config_init(&c1);
+	backup_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -351,8 +351,8 @@ START_TEST(test_init_bin_list)
 	tmp_file_init("", "bin-list=\"bin-1,bin-2,bin-3\"", "", "");
 	backup_config_t c1;
 	backup_config_t c2;
-	backup_config_default(&c1);
-	backup_config_default(&c2);
+	backup_config_init(&c1);
+	backup_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -370,8 +370,8 @@ START_TEST(test_init_mod_after)
 	tmp_file_init("", "modified-after=\"2000-01-01_00:00:00\"", "", "");
 	backup_config_t c1;
 	backup_config_t c2;
-	backup_config_default(&c1);
-	backup_config_default(&c2);
+	backup_config_init(&c1);
+	backup_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -400,8 +400,8 @@ START_TEST(test_init_mod_before)
 	tmp_file_init("", "modified-before=\"2000-01-01_00:00:00\"", "", "");
 	backup_config_t c1;
 	backup_config_t c2;
-	backup_config_default(&c1);
-	backup_config_default(&c2);
+	backup_config_init(&c1);
+	backup_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -430,8 +430,8 @@ START_TEST(test_init_s3_log_level)
 	tmp_file_init("", "s3-log-level=\"Debug\"\n", "", "");
 	backup_config_t c1;
 	backup_config_t c2;
-	backup_config_default(&c1);
-	backup_config_default(&c2);
+	backup_config_init(&c1);
+	backup_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -449,8 +449,8 @@ START_TEST(test_init_compress_mode)
 	tmp_file_init("", "compress=\"zstd\"\n", "", "");
 	backup_config_t c1;
 	backup_config_t c2;
-	backup_config_default(&c1);
-	backup_config_default(&c2);
+	backup_config_init(&c1);
+	backup_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -468,8 +468,8 @@ START_TEST(test_init_encryption_mode)
 	tmp_file_init("", "encrypt=\"aes128\"\n", "", "");
 	backup_config_t c1;
 	backup_config_t c2;
-	backup_config_default(&c1);
-	backup_config_default(&c2);
+	backup_config_init(&c1);
+	backup_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -640,8 +640,8 @@ START_TEST(test_init_encrypt_key_file)
 	tmp_file_init("", "encryption-key-file=\"test/test_key.pem\"\n", "", "");
 	backup_config_t c1;
 	backup_config_t c2;
-	backup_config_default(&c1);
-	backup_config_default(&c2);
+	backup_config_init(&c1);
+	backup_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -669,8 +669,8 @@ START_TEST(test_init_encryption_key_env)
 
 	backup_config_t c1;
 	backup_config_t c2;
-	backup_config_default(&c1);
-	backup_config_default(&c2);
+	backup_config_init(&c1);
+	backup_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 	unsetenv("TEST_ENCRYPT_KEY_ENV_VAR");
@@ -721,8 +721,8 @@ START_TEST(test_init_sa_ca_file)
 	tmp_file_init("", "", "", "sa-cafile=\"test/test_key.pem\"\n");
 	backup_config_t c1;
 	backup_config_t c2;
-	backup_config_default(&c1);
-	backup_config_default(&c2);
+	backup_config_init(&c1);
+	backup_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -743,8 +743,8 @@ START_TEST(test_name) \
 	tmp_file_init("", str_name "=true\n", "", ""); \
 	backup_config_t c1; \
 	backup_config_t c2; \
-	backup_config_default(&c1); \
-	backup_config_default(&c2); \
+	backup_config_init(&c1); \
+	backup_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	c2.field_name = true; \
@@ -765,8 +765,8 @@ START_TEST(test_name) \
 	tmp_file_init("", str_name "=314159\n", "", ""); \
 	backup_config_t c1; \
 	backup_config_t c2; \
-	backup_config_default(&c1); \
-	backup_config_default(&c2); \
+	backup_config_init(&c1); \
+	backup_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	c2.field_name = 314159lu * (mult); \
@@ -786,8 +786,8 @@ START_TEST(test_name) \
 	tmp_file_init("", str_name "=\"" str_val "\"\n", "", ""); \
 	backup_config_t c1; \
 	backup_config_t c2; \
-	backup_config_default(&c1); \
-	backup_config_default(&c2); \
+	backup_config_init(&c1); \
+	backup_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	c2.field_name = strdup(str_val); \
@@ -805,8 +805,8 @@ START_TEST(test_name) \
 	tmp_file_init("", str_name "=\"" str_val "\"\n", "", ""); \
 	backup_config_t c1; \
 	backup_config_t c2; \
-	backup_config_default(&c1); \
-	backup_config_default(&c2); \
+	backup_config_init(&c1); \
+	backup_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	strcpy(c2.field_name, val); \

--- a/test/unit/test_backup_conf.c
+++ b/test/unit/test_backup_conf.c
@@ -165,6 +165,7 @@ START_TEST(test_init_empty)
 	backup_config_t c2;
 	backup_config_init(&c1);
 	backup_config_init(&c2);
+	backup_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -183,6 +184,7 @@ START_TEST(test_name) \
 	backup_config_t c2; \
 	backup_config_init(&c1); \
 	backup_config_init(&c2); \
+	backup_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	c2.field_name = true; \
@@ -205,6 +207,7 @@ START_TEST(test_name) \
 	backup_config_t c2; \
 	backup_config_init(&c1); \
 	backup_config_init(&c2); \
+	backup_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	c2.field_name = 314159lu * (mult); \
@@ -226,6 +229,7 @@ START_TEST(test_name) \
 	backup_config_t c2; \
 	backup_config_init(&c1); \
 	backup_config_init(&c2); \
+	backup_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	cf_free(c2.field_name); \
@@ -245,6 +249,7 @@ START_TEST(test_name) \
 	backup_config_t c2; \
 	backup_config_init(&c1); \
 	backup_config_init(&c2); \
+	backup_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	cf_free((void*)c2.field_name); \
@@ -264,6 +269,7 @@ START_TEST(test_name) \
 	backup_config_t c2; \
 	backup_config_init(&c1); \
 	backup_config_init(&c2); \
+	backup_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	c2.field_name = 314159lu; \
@@ -313,6 +319,7 @@ START_TEST(test_init_set_list_single)
 	backup_config_t c2;
 	backup_config_init(&c1);
 	backup_config_init(&c2);
+	backup_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -332,6 +339,7 @@ START_TEST(test_init_set_list)
 	backup_config_t c2;
 	backup_config_init(&c1);
 	backup_config_init(&c2);
+	backup_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -353,6 +361,7 @@ START_TEST(test_init_bin_list)
 	backup_config_t c2;
 	backup_config_init(&c1);
 	backup_config_init(&c2);
+	backup_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -372,6 +381,7 @@ START_TEST(test_init_mod_after)
 	backup_config_t c2;
 	backup_config_init(&c1);
 	backup_config_init(&c2);
+	backup_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -402,6 +412,7 @@ START_TEST(test_init_mod_before)
 	backup_config_t c2;
 	backup_config_init(&c1);
 	backup_config_init(&c2);
+	backup_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -432,6 +443,7 @@ START_TEST(test_init_s3_log_level)
 	backup_config_t c2;
 	backup_config_init(&c1);
 	backup_config_init(&c2);
+	backup_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -451,6 +463,7 @@ START_TEST(test_init_compress_mode)
 	backup_config_t c2;
 	backup_config_init(&c1);
 	backup_config_init(&c2);
+	backup_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -470,6 +483,7 @@ START_TEST(test_init_encryption_mode)
 	backup_config_t c2;
 	backup_config_init(&c1);
 	backup_config_init(&c2);
+	backup_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -642,6 +656,7 @@ START_TEST(test_init_encrypt_key_file)
 	backup_config_t c2;
 	backup_config_init(&c1);
 	backup_config_init(&c2);
+	backup_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -671,6 +686,7 @@ START_TEST(test_init_encryption_key_env)
 	backup_config_t c2;
 	backup_config_init(&c1);
 	backup_config_init(&c2);
+	backup_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 	unsetenv("TEST_ENCRYPT_KEY_ENV_VAR");
@@ -723,6 +739,7 @@ START_TEST(test_init_sa_ca_file)
 	backup_config_t c2;
 	backup_config_init(&c1);
 	backup_config_init(&c2);
+	backup_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0);
 
@@ -745,6 +762,7 @@ START_TEST(test_name) \
 	backup_config_t c2; \
 	backup_config_init(&c1); \
 	backup_config_init(&c2); \
+	backup_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	c2.field_name = true; \
@@ -767,6 +785,7 @@ START_TEST(test_name) \
 	backup_config_t c2; \
 	backup_config_init(&c1); \
 	backup_config_init(&c2); \
+	backup_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	c2.field_name = 314159lu * (mult); \
@@ -788,6 +807,7 @@ START_TEST(test_name) \
 	backup_config_t c2; \
 	backup_config_init(&c1); \
 	backup_config_init(&c2); \
+	backup_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	c2.field_name = strdup(str_val); \
@@ -807,6 +827,7 @@ START_TEST(test_name) \
 	backup_config_t c2; \
 	backup_config_init(&c1); \
 	backup_config_init(&c2); \
+	backup_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, true), 0); \
 	strcpy(c2.field_name, val); \

--- a/test/unit/test_restore_conf.c
+++ b/test/unit/test_restore_conf.c
@@ -160,8 +160,8 @@ START_TEST(test_init_empty)
 	tmp_file_init("", "", "", "");
 	restore_config_t c1;
 	restore_config_t c2;
-	restore_config_default(&c1);
-	restore_config_default(&c2);
+	restore_config_init(&c1);
+	restore_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -178,8 +178,8 @@ START_TEST(test_name) \
 	tmp_file_init(str_name "=true\n", "", "", ""); \
 	restore_config_t c1; \
 	restore_config_t c2; \
-	restore_config_default(&c1); \
-	restore_config_default(&c2); \
+	restore_config_init(&c1); \
+	restore_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0); \
 	c2.field_name = true; \
@@ -200,8 +200,8 @@ START_TEST(test_name) \
 	tmp_file_init(str_name "=314159\n", "", "", ""); \
 	restore_config_t c1; \
 	restore_config_t c2; \
-	restore_config_default(&c1); \
-	restore_config_default(&c2); \
+	restore_config_init(&c1); \
+	restore_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0); \
 	c2.field_name = 314159lu * (mult); \
@@ -221,8 +221,8 @@ START_TEST(test_name) \
 	tmp_file_init(str_name "=\"" str_val "\"\n", "", "", ""); \
 	restore_config_t c1; \
 	restore_config_t c2; \
-	restore_config_default(&c1); \
-	restore_config_default(&c2); \
+	restore_config_init(&c1); \
+	restore_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0); \
 	cf_free(c2.field_name); \
@@ -266,8 +266,8 @@ START_TEST(test_init_set_list)
 	tmp_file_init("", "set-list=\"set-1,set-2,set-3\"", "", "");
 	restore_config_t c1;
 	restore_config_t c2;
-	restore_config_default(&c1);
-	restore_config_default(&c2);
+	restore_config_init(&c1);
+	restore_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -285,8 +285,8 @@ START_TEST(test_init_bin_list)
 	tmp_file_init("", "bin-list=\"bin-1,bin-2,bin-3\"", "", "");
 	restore_config_t c1;
 	restore_config_t c2;
-	restore_config_default(&c1);
-	restore_config_default(&c2);
+	restore_config_init(&c1);
+	restore_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -304,8 +304,8 @@ START_TEST(test_init_ns_list)
 	tmp_file_init("", "namespace=\"test\"", "", "");
 	restore_config_t c1;
 	restore_config_t c2;
-	restore_config_default(&c1);
-	restore_config_default(&c2);
+	restore_config_init(&c1);
+	restore_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -323,8 +323,8 @@ START_TEST(test_init_s3_log_level)
 	tmp_file_init("", "s3-log-level=\"Debug\"\n", "", "");
 	restore_config_t c1;
 	restore_config_t c2;
-	restore_config_default(&c1);
-	restore_config_default(&c2);
+	restore_config_init(&c1);
+	restore_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -342,8 +342,8 @@ START_TEST(test_init_compress_mode)
 	tmp_file_init("", "compress=\"zstd\"\n", "", "");
 	restore_config_t c1;
 	restore_config_t c2;
-	restore_config_default(&c1);
-	restore_config_default(&c2);
+	restore_config_init(&c1);
+	restore_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -361,8 +361,8 @@ START_TEST(test_init_encryption_mode)
 	tmp_file_init("", "encrypt=\"aes128\"\n", "", "");
 	restore_config_t c1;
 	restore_config_t c2;
-	restore_config_default(&c1);
-	restore_config_default(&c2);
+	restore_config_init(&c1);
+	restore_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -533,8 +533,8 @@ START_TEST(test_init_encrypt_key_file)
 	tmp_file_init("", "encryption-key-file=\"test/test_key.pem\"\n", "", "");
 	restore_config_t c1;
 	restore_config_t c2;
-	restore_config_default(&c1);
-	restore_config_default(&c2);
+	restore_config_init(&c1);
+	restore_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -562,8 +562,8 @@ START_TEST(test_init_encryption_key_env)
 
 	restore_config_t c1;
 	restore_config_t c2;
-	restore_config_default(&c1);
-	restore_config_default(&c2);
+	restore_config_init(&c1);
+	restore_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 	unsetenv("TEST_ENCRYPT_KEY_ENV_VAR");
@@ -614,8 +614,8 @@ START_TEST(test_init_sa_ca_file)
 	tmp_file_init("", "", "", "sa-cafile=\"test/test_key.pem\"\n");
 	restore_config_t c1;
 	restore_config_t c2;
-	restore_config_default(&c1);
-	restore_config_default(&c2);
+	restore_config_init(&c1);
+	restore_config_init(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -636,8 +636,8 @@ START_TEST(test_name) \
 	tmp_file_init("", str_name "=true\n", "", ""); \
 	restore_config_t c1; \
 	restore_config_t c2; \
-	restore_config_default(&c1); \
-	restore_config_default(&c2); \
+	restore_config_init(&c1); \
+	restore_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0); \
 	c2.field_name = true; \
@@ -658,8 +658,8 @@ START_TEST(test_name) \
 	tmp_file_init("", str_name "=314\n", "", ""); \
 	restore_config_t c1; \
 	restore_config_t c2; \
-	restore_config_default(&c1); \
-	restore_config_default(&c2); \
+	restore_config_init(&c1); \
+	restore_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0); \
 	c2.field_name = 314lu * (mult); \
@@ -679,8 +679,8 @@ START_TEST(test_name) \
 	tmp_file_init("", str_name "=\"" str_val "\"\n", "", ""); \
 	restore_config_t c1; \
 	restore_config_t c2; \
-	restore_config_default(&c1); \
-	restore_config_default(&c2); \
+	restore_config_init(&c1); \
+	restore_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0); \
 	cf_free(c2.field_name); \
@@ -698,8 +698,8 @@ START_TEST(test_name) \
 	tmp_file_init("", "", "", str_name "=\"" str_val "\"\n"); \
 	restore_config_t c1; \
 	restore_config_t c2; \
-	restore_config_default(&c1); \
-	restore_config_default(&c2); \
+	restore_config_init(&c1); \
+	restore_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0); \
 	cf_free(c2.field_name); \
@@ -717,8 +717,8 @@ START_TEST(test_name) \
 	tmp_file_init("", "", "", str_name "=314\n"); \
 	restore_config_t c1; \
 	restore_config_t c2; \
-	restore_config_default(&c1); \
-	restore_config_default(&c2); \
+	restore_config_init(&c1); \
+	restore_config_init(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0); \
 	c2.field_name = 314lu; \

--- a/test/unit/test_restore_conf.c
+++ b/test/unit/test_restore_conf.c
@@ -162,6 +162,7 @@ START_TEST(test_init_empty)
 	restore_config_t c2;
 	restore_config_init(&c1);
 	restore_config_init(&c2);
+	restore_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -180,6 +181,7 @@ START_TEST(test_name) \
 	restore_config_t c2; \
 	restore_config_init(&c1); \
 	restore_config_init(&c2); \
+	restore_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0); \
 	c2.field_name = true; \
@@ -202,6 +204,7 @@ START_TEST(test_name) \
 	restore_config_t c2; \
 	restore_config_init(&c1); \
 	restore_config_init(&c2); \
+	restore_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0); \
 	c2.field_name = 314159lu * (mult); \
@@ -223,6 +226,7 @@ START_TEST(test_name) \
 	restore_config_t c2; \
 	restore_config_init(&c1); \
 	restore_config_init(&c2); \
+	restore_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0); \
 	cf_free(c2.field_name); \
@@ -268,6 +272,7 @@ START_TEST(test_init_set_list)
 	restore_config_t c2;
 	restore_config_init(&c1);
 	restore_config_init(&c2);
+	restore_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -287,6 +292,7 @@ START_TEST(test_init_bin_list)
 	restore_config_t c2;
 	restore_config_init(&c1);
 	restore_config_init(&c2);
+	restore_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -306,6 +312,7 @@ START_TEST(test_init_ns_list)
 	restore_config_t c2;
 	restore_config_init(&c1);
 	restore_config_init(&c2);
+	restore_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -325,6 +332,7 @@ START_TEST(test_init_s3_log_level)
 	restore_config_t c2;
 	restore_config_init(&c1);
 	restore_config_init(&c2);
+	restore_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -344,6 +352,7 @@ START_TEST(test_init_compress_mode)
 	restore_config_t c2;
 	restore_config_init(&c1);
 	restore_config_init(&c2);
+	restore_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -363,6 +372,7 @@ START_TEST(test_init_encryption_mode)
 	restore_config_t c2;
 	restore_config_init(&c1);
 	restore_config_init(&c2);
+	restore_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -535,6 +545,7 @@ START_TEST(test_init_encrypt_key_file)
 	restore_config_t c2;
 	restore_config_init(&c1);
 	restore_config_init(&c2);
+	restore_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -564,6 +575,7 @@ START_TEST(test_init_encryption_key_env)
 	restore_config_t c2;
 	restore_config_init(&c1);
 	restore_config_init(&c2);
+	restore_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 	unsetenv("TEST_ENCRYPT_KEY_ENV_VAR");
@@ -616,6 +628,7 @@ START_TEST(test_init_sa_ca_file)
 	restore_config_t c2;
 	restore_config_init(&c1);
 	restore_config_init(&c2);
+	restore_config_set_heap_defaults(&c2);
 
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0);
 
@@ -638,6 +651,7 @@ START_TEST(test_name) \
 	restore_config_t c2; \
 	restore_config_init(&c1); \
 	restore_config_init(&c2); \
+	restore_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0); \
 	c2.field_name = true; \
@@ -660,6 +674,7 @@ START_TEST(test_name) \
 	restore_config_t c2; \
 	restore_config_init(&c1); \
 	restore_config_init(&c2); \
+	restore_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0); \
 	c2.field_name = 314lu * (mult); \
@@ -681,6 +696,7 @@ START_TEST(test_name) \
 	restore_config_t c2; \
 	restore_config_init(&c1); \
 	restore_config_init(&c2); \
+	restore_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0); \
 	cf_free(c2.field_name); \
@@ -700,6 +716,7 @@ START_TEST(test_name) \
 	restore_config_t c2; \
 	restore_config_init(&c1); \
 	restore_config_init(&c2); \
+	restore_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0); \
 	cf_free(c2.field_name); \
@@ -719,6 +736,7 @@ START_TEST(test_name) \
 	restore_config_t c2; \
 	restore_config_init(&c1); \
 	restore_config_init(&c2); \
+	restore_config_set_heap_defaults(&c2); \
 	\
 	ck_assert_int_ne(config_from_file(&c1, NULL, file_name, 0, false), 0); \
 	c2.field_name = 314lu; \


### PR DESCRIPTION
Fixes small config memory leaks when asbackup/restore is used as a shared lib. These occur when users overwrite heap allocated config default values.