### PR TITLE
build: explicitly link with libcurl in both static and dynamic s3 sdk…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,13 @@ ifeq ($(AWS_SDK_STATIC_PATH),)
   LIBRARIES += -laws-checksums
   LIBRARIES += -laws-c-cal
   LIBRARIES += -laws-c-common
+
+  ifeq ($(CURL_STATIC_PATH),)
+    LIBRARIES += -lcurl
+  else
+    LIBRARIES += $(CURL_STATIC_PATH)/libcurl.a
+  endif
+
 else
   # do not change the order of these
   LIBRARIES += $(AWS_SDK_STATIC_PATH)/libaws-cpp-sdk-s3.a


### PR DESCRIPTION
… builds

relates to this slack thread https://aerospike.slack.com/archives/C02JNQ0Q2/p1711634891157759

While not the most beautiful way to add this, I think this is safest since it does not disturb the order of arguments to the linker.