### PR TITLE
Fix mac build

### DIFF
--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -218,7 +218,7 @@ jobs:
         path: ${{ steps.working-dir.outputs.value }}/binaries/static_bin/asbackup
         if-no-files-found: error
     - name: Upload static asrestore artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with: 
         name: ${{ steps.system-info.outputs.platform }}-${{ runner.arch }}-${{ runner.os }}-${{ steps.system-info.outputs.release }}-asrestore-static
         path: ${{ steps.working-dir.outputs.value }}/binaries/static_bin/asrestore

--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -1,9 +1,9 @@
 name: Mac Artifact
 on:
   push:
-    branches: [ master, "bugfix-*" ]
+    branches: [ master, "bugfix-*", actions-hub ]
   pull_request:
-    branches: [ master, "bugfix-*" ]
+    branches: [ master, "bugfix-*", actions-hub ]
   workflow_call:
     inputs:
       submodule:

--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -212,7 +212,7 @@ jobs:
         ./asrestore -n test -d backupdir 2>&1 | grep "Failed to connect"
       working-directory:  ${{ steps.working-dir.outputs.value }}/binaries/static_bin
     - name: Upload static asbackup artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with: 
         name: ${{ steps.system-info.outputs.platform }}-${{ runner.arch }}-${{ runner.os }}-${{ steps.system-info.outputs.release }}-asbackup-static
         path: ${{ steps.working-dir.outputs.value }}/binaries/static_bin/asbackup

--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -235,7 +235,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: binaries
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: binaries
           path: binaries


### PR DESCRIPTION
Revert upload actions to v3. V4 is causing issues when downloading the artifacts into the meta package. The artifact looks to be uploaded properly 