### PR TITLE
fix: tools-2941 properly upload state files to s3.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aerospike~=14.0.0
+aerospike~=14.2.0
 docker
 pytest
 pylint

--- a/src/backup_state.c
+++ b/src/backup_state.c
@@ -136,8 +136,11 @@ backup_state_save(backup_state_t* state)
 	}
 
 	if (file_proxy_truncate(state->file) != 0) {
-		err("Unable to truncate backup state file");
+		inf("Warning: Unable to truncate backup state file");
 		// don't treat this as a critical error
+		// this always happens when the backup state is 
+		// being written to S3 because file_proxy_s3_truncate
+		// is a no-op that returns EOF
 	}
 
 	// commit the backup state to the file

--- a/src/upload_manager.cc
+++ b/src/upload_manager.cc
@@ -372,14 +372,9 @@ bool
 UploadManager::_UploadPart(int part_number,
 		std::shared_ptr<Aws::StringStream>& body)
 {
-	// Don't try uploading this part if the backup has been stopped, just
-	// immediately mark the part as failed and return.
 	backup_status_t* backup_status = get_g_backup_status();
 	if (backup_status_has_stopped(backup_status)) {
-		async_finished_mutex.lock();
-		failed_part_list.emplace_back(part_number, body);
-		async_finished_mutex.unlock();
-		return true;
+		inf("Upload manager received stop signal, finishing part: %d", part_number);
 	}
 
 	g_api.RegisterAsyncUpload();

--- a/test/integration/test_s3.py
+++ b/test/integration/test_s3.py
@@ -77,10 +77,10 @@ def do_s3_backup(max_interrupts, n_records=10000, backup_opts=None,
 				state_path = "s3://" + S3_BUCKET + "/test_dir"
 				state_file = state_path + "/" + lib.NAMESPACE + '.asb.state'
 				state_path = state_file
-			elif state_file_dir:
+			else:
 				# state path cannot be the same as backup directory
-				state_path = "s3://" + S3_BUCKET + "/state_dir"
-				state_file = state_path + "/" + lib.NAMESPACE + '.asb.state'
+				state_path = "s3://" + S3_BUCKET + "/state_file.asb.state"
+				state_file = state_path
 
 		while True:
 			opts = comp_enc_mode + backup_opts

--- a/test/integration/test_s3.py
+++ b/test/integration/test_s3.py
@@ -73,10 +73,14 @@ def do_s3_backup(max_interrupts, n_records=10000, backup_opts=None,
 			state_file = state_path
 		
 		if state_file_to_s3:
-			state_path = "s3://" + S3_BUCKET + "/test_dir"
-			state_file = state_path + "/" + lib.NAMESPACE + '.asb.state'
 			if state_file_explicit:
+				state_path = "s3://" + S3_BUCKET + "/test_dir"
+				state_file = state_path + "/" + lib.NAMESPACE + '.asb.state'
 				state_path = state_file
+			elif state_file_dir:
+				# state path cannot be the same as backup directory
+				state_path = "s3://" + S3_BUCKET + "/state_dir"
+				state_file = state_path + "/" + lib.NAMESPACE + '.asb.state'
 
 		while True:
 			opts = comp_enc_mode + backup_opts


### PR DESCRIPTION
State files could not be uploaded to S3 due to a race condition where the upload manager was told to stop uploads before the state file could be written to s3.