### PR TITLE
chore: TOOLS-3144 Update macOS build matrix to remove macos-13

### DIFF
--- a/.github/workflows/backup-build.yml
+++ b/.github/workflows/backup-build.yml
@@ -45,7 +45,7 @@ jobs:
         path: aws-sdk-cpp
         key: aws-sdk-cpp-build-and-test-${{ env.AWS_SDK_CPP_VERSION }}-${{ runner.os }}
     - name: Download AWS C++ sdk
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: steps.cache-aws-sdk-cpp.outputs.cache-hit != 'true'
       with:
         repository: aws/aws-sdk-cpp
@@ -64,7 +64,7 @@ jobs:
         cd aws-sdk-cpp/build
         sudo make install
     - name: Download zstd
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: facebook/zstd
         submodules: recursive
@@ -115,7 +115,7 @@ jobs:
         sudo make install
         sudo ldconfig
     - name: Checkout c client
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: aerospike/aerospike-client-c
         submodules: recursive
@@ -125,7 +125,7 @@ jobs:
       run: make
       working-directory: client
     - name: Checkout asbackup
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with: 
         path: main
         submodules: recursive

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Draft Release
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Upload Artifacts to Release Draft
       uses: "softprops/action-gh-release@v1"
       with:

--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -91,7 +91,7 @@ jobs:
         path: aws-sdk-cpp-${{ env.AWS_SDK_CPP_VERSION }}
         key: aws-sdk-cpp-${{ env.cache-index }}-mac-artifact-${{ env.AWS_SDK_CPP_VERSION }}-${{ matrix.os }}-${{ runner.arch }}-cmake-${{ env.CMAKE_VERSION }}
     - name: Download AWS C++ sdk
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: steps.cache-aws-sdk-cpp.outputs.cache-hit != 'true'
       with:
         repository: aws/aws-sdk-cpp
@@ -115,7 +115,7 @@ jobs:
         path: libssh2-${{ env.LIBSSH2_VERSION }}
         key: libssh2-v2-${{ env.LIBSSH2_VERSION }}-${{ env.cache-index }}-${{ matrix.os }}-${{ runner.arch }}-cmake-${{ env.CMAKE_VERSION }}
     - name: Download libssh2
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: steps.cache-libssh2.outputs.cache-hit != 'true'
       with:
         repository: libssh2/libssh2
@@ -144,7 +144,7 @@ jobs:
         path: curl-${{ env.LIBCURL_VERSION }}
         key: curl-v2-${{ env.LIBCURL_VERSION }}-${{ env.cache-index }}-${{ matrix.os }}-${{ runner.arch }}-cmake-${{ env.CMAKE_VERSION }}
     - name: Download libcurl
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: steps.cache-libcurl.outputs.cache-hit != 'true'
       with:
         repository: curl/curl
@@ -163,7 +163,7 @@ jobs:
         sudo make install
       working-directory: curl-${{ env.LIBCURL_VERSION }}/build
     - name: Download zstd
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: facebook/zstd
         submodules: recursive
@@ -189,7 +189,7 @@ jobs:
       working-directory: zstd-${{ env.ZSTD_VERSION }}
       # this will checkout the whole tools repo when run from aerospike-tools, but we will
       # just cd into the correct directory calculated from working-dir
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       if: steps.cache-asbackup.outputs.cache-hit != 'true'
       with: 
         path: ${{ steps.checkout-dir.outputs.value }}

--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -15,16 +15,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-13, macos-14, macos-15]
+        os: [macos-14, macos-15]
         include:
-          - os: macos-13
-            openssl-path: /usr/local/opt/openssl
-            zstd-path: /usr/local
-            aws-sdk-path: /usr/local
-            curl-path: /usr/local
-            ssh2-path: /usr/local
-            uv-path: /usr/local
-            jansson-path: /usr/local
           - os: macos-14
             openssl-path: /opt/homebrew/opt/openssl
             zstd-path: /opt/homebrew


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to use the latest version of the `actions/checkout` action and removes support for building on macOS 13. These changes help ensure better compatibility, security, and support for newer features in the CI/CD pipeline.


**macOS build matrix update:**

* Removed `macos-13` from the build matrix in `.github/workflows/mac-artifact.yml`, so builds now only run on `macos-14` and `macos-15`, and the associated configuration for `macos-13` was deleted.