### PR TITLE
chore: update git describe command to use --abbrev=9 for versioning in Makefile and workflow

### DIFF
--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -211,8 +211,8 @@ jobs:
       working-directory: ${{ steps.working-dir.outputs.value }}
       id: tag
       run: |
-        git describe --tags --always
-        echo "tag=$(git describe --tags --always)" >> $GITHUB_OUTPUT
+        git describe --tags --always --abbrev=9
+        echo "tag=$(git describe --tags --always --abbrev=9)" >> $GITHUB_OUTPUT
     - name: Cache asbackup build
       id: cache-asbackup
       uses: actions/cache@v3

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 OS := $(shell uname -s)
 ARCH := $(shell uname -m)
 PLATFORM := $(OS)-$(ARCH)
-VERSION := $(shell git describe --abbrev=9 2>/dev/null; if [ $${?} != 0 ]; then echo 'unknown'; fi)
+VERSION := $(shell git describe --tags --always --abbrev=9 2>/dev/null; if [ $${?} != 0 ]; then echo 'unknown'; fi)
 ROOT = $(CURDIR)
 
 M1_HOME_BREW =

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 OS := $(shell uname -s)
 ARCH := $(shell uname -m)
 PLATFORM := $(OS)-$(ARCH)
-VERSION := $(shell git describe 2>/dev/null; if [ $${?} != 0 ]; then echo 'unknown'; fi)
+VERSION := $(shell git describe --abbrev=9 2>/dev/null; if [ $${?} != 0 ]; then echo 'unknown'; fi)
 ROOT = $(CURDIR)
 
 M1_HOME_BREW =


### PR DESCRIPTION
This pull request updates how git version tags are generated in both the GitHub Actions workflow and the Makefile. The main change is to use the `--abbrev=9` option with `git describe`, which ensures that abbreviated commit hashes are consistently 9 characters long. This helps standardize version strings across builds.

Versioning improvements:

* Updated the `git describe` command in `.github/workflows/mac-artifact.yml` to use `--abbrev=9`, ensuring that generated tags include a 9-character abbreviated commit hash.
* Updated the `VERSION` variable in the `Makefile` to use `git describe --abbrev=9`, standardizing version output for local builds as well.