### PR TITLE
fix: TOOLS-3183 Add macOS x64 build support

### DIFF
--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -15,8 +15,18 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-14, macos-15, macos-26]
+        os: [macos-15-intel, macos-14, macos-15, macos-26]
         include:
+          # x86_64 native build
+          - os: macos-15-intel
+            openssl-path: /usr/local/opt/openssl@3
+            zstd-path: /usr/local
+            aws-sdk-path: /usr/local
+            curl-path: /usr/local
+            ssh2-path: /usr/local
+            uv-path: /usr/local
+            jansson-path: /usr/local
+          # ARM64 native builds
           - os: macos-14
             openssl-path: /opt/homebrew/opt/openssl@3
             zstd-path: /opt/homebrew


### PR DESCRIPTION
Add macos-15-intel runner to the build matrix with x86_64-specific paths for all dependencies (openssl, zstd, aws-sdk, curl, ssh2, uv, jansson) at /usr/local prefix.