### PR TITLE
chore: TOOLS-3143 Remove deprecated info command `version`

### DIFF
--- a/.github/packaging/project/build_package.sh
+++ b/.github/packaging/project/build_package.sh
@@ -11,6 +11,9 @@ function build_packages(){
   git config --global --add safe.directory '*'
   git submodule update --init --recursive
   export ARCH=$(uname -m)
+  if [ -n "${PKG_VERSION:-}" ]; then
+    export VERSION="$PKG_VERSION"
+  fi
   if [ "$ENV_DISTRO" = "debian13" ]; then
     export CMAKE_ROOT=/opt/cmake-3.27.0-linux-x86_64/
   fi

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -193,6 +193,7 @@ jobs:
         BUILD_BUILDER_IMAGES=${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.BUILD_BUILDER_IMAGES) || 'false' }}  \
         IMAGE_TAG=${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.DOCKER_TAG) || 'latest' }} \
         BUILDER_IMAGE_PREFIX="artifact.aerospike.io/database-container-dev-local/aerospike-tools/" \
+        PKG_VERSION=${{ needs.get-version.outputs.VERSION }} \
         local/.github/packaging/project/gha-main.sh "${{ matrix.distro }}"
       gh-artifact-directory: dist
       gh-artifact-name: unsigned-artifacts-${{ needs.get-version.outputs.VERSION }}-${{ matrix.distro }}-${{ contains(matrix.host, 'arm') && 'aarch64' || 'x86_64' }}

--- a/include/restore_status.h
+++ b/include/restore_status.h
@@ -48,8 +48,8 @@ typedef struct restore_status {
 	// The Aerospike client.
 	// NOTE this is NULL if validate is true
 	aerospike* as;
-	// Server version info struct.
-	server_version_t version_info;
+	// Server build info struct.
+	server_build_t build_info;
 
 	// The file format decoder to be used for reading data from a backup file.
 	backup_decoder_t decoder;

--- a/include/utils.h
+++ b/include/utils.h
@@ -300,15 +300,15 @@ typedef struct {
 } b64_context;
 
 /*
- * Struct containing server version information.
+ * Struct containing server build information.
+ * Build format: "<epoch>.<major>.<minor>.<patch>"
  */
-typedef struct server_version {
-	// server version looks like "<major>.<minor>.<patch>.<build_id>"
+typedef struct server_build {
+	uint32_t epoch;
 	uint32_t major;
 	uint32_t minor;
 	uint32_t patch;
-	uint32_t build_id;
-} server_version_t;
+} server_build_t;
 
 extern const uint8_t b64map[256];
 
@@ -340,9 +340,9 @@ extern const uint8_t b64map[256];
 
 #endif /* __APPLE__ */
 
-#define SERVER_VERSION_BEFORE(version_info, _major, _minor) \
-	((version_info)->major < _major || \
-	 ((version_info)->major == _major && (version_info)->minor < _minor))
+#define SERVER_BUILD_BEFORE(build_info, _epoch, _major) \
+	((build_info)->epoch < (_epoch) || \
+	 ((build_info)->epoch == (_epoch) && (build_info)->major < (_major)))
 
 
 //==========================================================
@@ -446,10 +446,10 @@ bool parse_index_info(char *ns, char *index_str, index_param *index);
 bool parse_set_list(as_vector* dst, const char* set_list);
 encryption_key_t* parse_encryption_key_env(const char* env_var_name);
 
-// Gets the current server version via an info command, returning 0 on success
-// and nonzero on failure.
-int get_server_version(aerospike* as, server_version_t*);
-bool server_has_batch_writes(aerospike* as, const server_version_t*,
+// Gets the current server build version via an info command, returning 0 on
+// success and nonzero on failure.
+int get_server_build(aerospike* as, server_build_t*);
+bool server_has_batch_writes(aerospike* as, const server_build_t*,
 		bool* batch_writes_enabled);
 
 /*

--- a/src/restore_status.c
+++ b/src/restore_status.c
@@ -174,20 +174,20 @@ restore_status_init(restore_status_t* status, const restore_config_t* conf)
 		goto cleanup4;
 	}
 
-	if (get_server_version(info_as, &status->version_info) != 0) {
+	if (get_server_build(info_as, &status->build_info) != 0) {
 		goto cleanup5;
 	}
 
-	ver("Connected to server version %u.%u.%u.%u",
-			status->version_info.major,
-			status->version_info.minor,
-			status->version_info.patch,
-			status->version_info.build_id);
+	ver("Connected to server build %u.%u.%u.%u",
+			status->build_info.epoch,
+			status->build_info.major,
+			status->build_info.minor,
+			status->build_info.patch);
 
 	if (conf->disable_batch_writes) {
 		status->batch_writes_enabled = false;
 	}
-	else if (!server_has_batch_writes(info_as, &status->version_info,
+	else if (!server_has_batch_writes(info_as, &status->build_info,
 				&status->batch_writes_enabled)) {
 		goto cleanup5;
 	}
@@ -208,10 +208,10 @@ restore_status_init(restore_status_t* status, const restore_config_t* conf)
 		goto cleanup5;
 	}
 
-	if (SERVER_VERSION_BEFORE(&status->version_info, 4, 9)) {
+	if (SERVER_BUILD_BEFORE(&status->build_info, 4, 9)) {
 		err("Aerospike Server version 4.9 or greater is required to run "
 				"asrestore, but version %" PRIu32 ".%" PRIu32 " is in use.",
-				status->version_info.major, status->version_info.minor);
+				status->build_info.epoch, status->build_info.major);
 		goto cleanup5;
 	}
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1791,10 +1791,17 @@ get_server_build(aerospike* as, server_build_t* build_info)
 		return -1;
 	}
 
-	if (sscanf(response, "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32,
+	char* build_str = NULL;
+	if (as_info_parse_single_response(response, &build_str) != AEROSPIKE_OK) {
+		err("Failed to parse server build info response: %s\n", response);
+		cf_free(response);
+		return -1;
+	}
+
+	if (sscanf(build_str, "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32,
 				&build_info->epoch, &build_info->major,
 				&build_info->minor, &build_info->patch) != 4) {
-		err("Invalid server build response: %s\n", response);
+		err("Invalid server build response: %s\n", build_str);
 		cf_free(response);
 		return -1;
 	}


### PR DESCRIPTION
- Updated `restore_status.h` and `utils.h` to replace `server_version_t` with `server_build_t`.
- Modified functions to retrieve and check server build information instead of version.
- Adjusted logging and error handling to reflect changes in server build structure.
- Ensured compatibility checks now reference server build instead of version.