### PR TITLE
fix: TOOLS-3510 Backup file extension truncated from .asb to .as when count over 100k

### DIFF
--- a/src/backup.c
+++ b/src/backup.c
@@ -1395,6 +1395,7 @@ open_dir_file(backup_job_context_t *bjc)
 			pthread_mutex_unlock(&bjc->status->dir_file_init_mutex);
 			cf_free(bjc->fd);
 			bjc->fd = NULL;
+			err("Unable to malloc file path name");
 			return false;
 		}
 

--- a/src/backup.c
+++ b/src/backup.c
@@ -1394,13 +1394,12 @@ open_dir_file(backup_job_context_t *bjc)
 
 		char* file_path = (char*) cf_malloc((file_path_size + 1) * sizeof(char));
 		if (file_path == NULL) {
+			pthread_mutex_unlock(&bjc->status->dir_file_init_mutex);
 			cf_free(bjc->fd);
 			bjc->fd = NULL;
 			err("Unable to malloc file path name of length %" PRIu64, file_path_size);
 			return false;
 		}
-
-
 
 		snprintf(file_path, file_path_size + 1, "%s/%s_%05" PRId64 ".asb",
 				bjc->conf->directory,

--- a/src/backup.c
+++ b/src/backup.c
@@ -1384,6 +1384,9 @@ open_dir_file(backup_job_context_t *bjc)
 			return false;
 		}
 
+		pthread_mutex_lock(&bjc->status->dir_file_init_mutex);
+		int64_t file_count = bjc->status->file_count;
+
 		uint64_t file_path_size = (size_t) snprintf(NULL, 0, "%s/%s_%05" PRId64 ".asb",
 				bjc->conf->directory,
 				bjc->conf->prefix == NULL ? bjc->conf->ns : bjc->conf->prefix,
@@ -1397,8 +1400,7 @@ open_dir_file(backup_job_context_t *bjc)
 			return false;
 		}
 
-		pthread_mutex_lock(&bjc->status->dir_file_init_mutex);
-		int64_t file_count = bjc->status->file_count;
+
 
 		snprintf(file_path, file_path_size + 1, "%s/%s_%05" PRId64 ".asb",
 				bjc->conf->directory,

--- a/src/backup.c
+++ b/src/backup.c
@@ -1384,10 +1384,10 @@ open_dir_file(backup_job_context_t *bjc)
 			return false;
 		}
 
-		uint64_t file_path_size = (size_t) snprintf(NULL, 0, "%s/%s_%05d.asb",
+		uint64_t file_path_size = (size_t) snprintf(NULL, 0, "%s/%s_%05.asb",
 				bjc->conf->directory,
 				bjc->conf->prefix == NULL ? bjc->conf->ns : bjc->conf->prefix,
-				0);
+				file_count);
 
 		char* file_path = (char*) cf_malloc((file_path_size + 1) * sizeof(char));
 		if (file_path == NULL) {

--- a/src/backup.c
+++ b/src/backup.c
@@ -1384,7 +1384,7 @@ open_dir_file(backup_job_context_t *bjc)
 			return false;
 		}
 
-		uint64_t file_path_size = (size_t) snprintf(NULL, 0, "%s/%s_%05.asb",
+		uint64_t file_path_size = (size_t) snprintf(NULL, 0, "%s/%s_%05" PRId64 ".asb",
 				bjc->conf->directory,
 				bjc->conf->prefix == NULL ? bjc->conf->ns : bjc->conf->prefix,
 				file_count);

--- a/src/backup.c
+++ b/src/backup.c
@@ -1387,27 +1387,16 @@ open_dir_file(backup_job_context_t *bjc)
 		pthread_mutex_lock(&bjc->status->dir_file_init_mutex);
 		int64_t file_count = bjc->status->file_count;
 
-		uint64_t file_path_size = (size_t) snprintf(NULL, 0, "%s/%s_%05" PRId64 ".asb",
+		char* file_path = dyn_sprintf("%s/%s_%05" PRId64 ".asb",
 				bjc->conf->directory,
 				bjc->conf->prefix == NULL ? bjc->conf->ns : bjc->conf->prefix,
 				file_count);
-
-		char* file_path = dyn_sprintf("%s/%s_%05" PRId64 ".asb",
-        bjc->conf->directory,
-        bjc->conf->prefix == NULL ? bjc->conf->ns : bjc->conf->prefix,
-        file_count);
 		if (file_path == NULL) {
 			pthread_mutex_unlock(&bjc->status->dir_file_init_mutex);
 			cf_free(bjc->fd);
 			bjc->fd = NULL;
-			err("Unable to malloc file path name of length %" PRIu64, file_path_size);
 			return false;
 		}
-
-		snprintf(file_path, file_path_size + 1, "%s/%s_%05" PRId64 ".asb",
-				bjc->conf->directory,
-				bjc->conf->prefix == NULL ? bjc->conf->ns : bjc->conf->prefix,
-				file_count);
 
 		if (!open_file(file_path, bjc->conf->ns,
 					MIN(remaining_bytes, bjc->conf->file_limit), bjc->fd,
@@ -1420,7 +1409,6 @@ open_dir_file(backup_job_context_t *bjc)
 			cf_free(file_path);
 			return false;
 		}
-		cf_free(file_path);
 
 		bjc->rec_count_file = 0;
 		bjc->byte_count_file = 0;
@@ -1430,8 +1418,10 @@ open_dir_file(backup_job_context_t *bjc)
 			cf_free(bjc->fd);
 			bjc->fd = NULL;
 			err("New directory file %s, failed to get file position", file_path);
+			cf_free(file_path);
 			return false;
 		}
+		cf_free(file_path);
 
 		bjc->status->file_count = file_count + 1;
 		pthread_mutex_unlock(&bjc->status->dir_file_init_mutex);

--- a/src/backup.c
+++ b/src/backup.c
@@ -1392,7 +1392,10 @@ open_dir_file(backup_job_context_t *bjc)
 				bjc->conf->prefix == NULL ? bjc->conf->ns : bjc->conf->prefix,
 				file_count);
 
-		char* file_path = (char*) cf_malloc((file_path_size + 1) * sizeof(char));
+		char* file_path = dyn_sprintf("%s/%s_%05" PRId64 ".asb",
+        bjc->conf->directory,
+        bjc->conf->prefix == NULL ? bjc->conf->ns : bjc->conf->prefix,
+        file_count);
 		if (file_path == NULL) {
 			pthread_mutex_unlock(&bjc->status->dir_file_init_mutex);
 			cf_free(bjc->fd);


### PR DESCRIPTION
When count of backup files exceeds 100000 the backup file name is truncated from .asb to .as This affects asrestore lookign for .abs

By using file_count and the %05" PRId64 " specifier in the sizing call:

Correct Calculation: When file_count is 100,000, snprintf will accurately report that it needs space for 6 digits instead of 5.  

Sufficient Allocation: The subsequent cf_malloc((file_path_size + 1)) will then allocate enough memory for the full .asb extension.  

No Truncation: The final snprintf (around line 1400) will no longer drop the 'b' to fit the string into the buffer.