### PR TITLE
ci: build and test Docker images on dry-run, push only on release

### DIFF
--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -341,12 +341,14 @@ function compile_deps_el8() {
   make install
 
   pushd /opt
-  git clone https://git.savannah.gnu.org/git/readline.git
-  pushd readline
-  git checkout readline-8.3
+  curl -LO https://mirrors.ocf.berkeley.edu/gnu/readline/readline-8.3.tar.gz
+  tar -zxvf readline-8.3.tar.gz
+  pushd readline-8.3
   ./configure
   make_parallel
   make install
+  popd
+  rm -rf /opt/readline-8.3 /opt/readline-8.3.tar.gz
 
   pushd /opt
   git clone https://github.com/akheron/jansson.git
@@ -406,12 +408,14 @@ function compile_deps_el9() {
   make install
 
   pushd /opt
-  git clone https://git.savannah.gnu.org/git/readline.git
-  pushd readline
-  git checkout readline-8.3
+  curl -LO https://mirrors.ocf.berkeley.edu/gnu/readline/readline-8.3.tar.gz
+  tar -zxvf readline-8.3.tar.gz
+  pushd readline-8.3
   ./configure
   make_parallel
   make install
+  popd
+  rm -rf /opt/readline-8.3 /opt/readline-8.3.tar.gz
 
   pushd /opt
   git clone https://github.com/akheron/jansson.git
@@ -500,12 +504,14 @@ EOF
   make install
 
   pushd /opt
-  git clone https://git.savannah.gnu.org/git/readline.git
-  pushd readline
-  git checkout readline-8.3
+  curl -LO https://mirrors.ocf.berkeley.edu/gnu/readline/readline-8.3.tar.gz
+  tar -zxvf readline-8.3.tar.gz
+  pushd readline-8.3
   ./configure
   make_parallel
   make install
+  popd
+  rm -rf /opt/readline-8.3 /opt/readline-8.3.tar.gz
 
   pushd /opt
   git clone https://github.com/akheron/jansson.git
@@ -564,12 +570,14 @@ function install_deps_amzn2023() {
   make install
 
   pushd /opt
-  git clone https://git.savannah.gnu.org/git/readline.git
-  pushd readline
-  git checkout readline-8.3
+  curl -LO https://mirrors.ocf.berkeley.edu/gnu/readline/readline-8.3.tar.gz
+  tar -zxvf readline-8.3.tar.gz
+  pushd readline-8.3
   ./configure
   make_parallel
   make install
+  popd
+  rm -rf /opt/readline-8.3 /opt/readline-8.3.tar.gz
 
   pushd /opt
   git clone https://github.com/akheron/jansson.git

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -782,7 +782,6 @@ jobs:
 
   docker-build-arch:
     name: Docker build, test & push (${{ matrix.arch }})
-    if: inputs.release == true
     needs: [get-version, organize-signed-artifacts]
     strategy:
       fail-fast: false
@@ -816,6 +815,7 @@ jobs:
         run: npm install -g snyk@1.1304.3
 
       - name: Install JFrog CLI
+        if: inputs.release == true
         id: jf
         uses: step-security/setup-jfrog-cli@893a92f96c7727242adf0e603c77b1f2a22390e1 # v4.9.1
         env:
@@ -827,6 +827,7 @@ jobs:
           oidc-audience: database-gh-aerospike
 
       - name: Docker login to Artifactory
+        if: inputs.release == true
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: artifact.aerospike.io
@@ -875,6 +876,7 @@ jobs:
           fi
 
       - name: Push native per-arch tag to JFrog
+        if: inputs.release == true
         env:
           VERSION: ${{ needs.get-version.outputs.VERSION }}
         run: |
@@ -887,6 +889,7 @@ jobs:
 
   docker-manifest:
     name: Docker multi-arch manifest (stitch native tags)
+    if: inputs.release == true
     needs: [get-version, docker-build-arch]
     runs-on: ubuntu-24.04
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ null.d
 # docker bake / staged debs (generated locally)
 docker/docker-bake.hcl
 docker/aerospike-asbackup_*.deb
+
+# shared packaging submodule (checked out locally, not tracked in this repo)
+.github/packaging/


### PR DESCRIPTION
## Summary

- Removes the job-level `if: inputs.release == true` guard from `docker-build-arch` so Docker images are **always** built and smoke-tested, even during dry-run dispatches (`release=false`)
- Moves the publish gate (`if: inputs.release == true`) down to the three push-only steps: **Install JFrog CLI**, **Docker login to Artifactory**, and **Push native per-arch tag to JFrog**
- Adds `if: inputs.release == true` to the `docker-manifest` job (pure push operation — no change to behaviour when `release=true`)

## Behaviour after this change

| Step | `release=false` (dry-run) | `release=true` (publish) |
|---|---|---|
| Docker build + smoke test | ✅ now runs | ✅ |
| JFrog login / push per-arch tag | ❌ skipped | ✅ |
| Docker multi-arch manifest | ❌ skipped | ✅ |

## Test plan
- [ ] Dispatch with `release=false` and confirm docker-build-arch runs build/test steps but skips JFrog login and push
- [ ] Dispatch with `release=true` and confirm full publish flow is unchanged