### PR TITLE
fix: TOOLS-3624 handle backup state initialization on stop request during S3 API setup

### DIFF
--- a/src/backup.c
+++ b/src/backup.c
@@ -671,32 +671,6 @@ start_backup(backup_config_t* conf)
 
 	backup_status_start(status);
 
-	// If a stop was requested before backup_status_start ran (typically a
-	// SIGINT during S3 API initialization), backup_status_stop deliberately
-	// left backup_state NULL rather than risk a deadlock by opening the state
-	// file from the signal handler. Initialize it now from a safe context so
-	// the worker threads (which are about to be spawned and will see stop=true)
-	// have somewhere to write partition state, and signal one_shot so the
-	// cleanup save-state path (gated on backup_status_one_shot_done) actually
-	// flushes the state file to disk.
-	//
-	// Init and one_shot signaling are kept independent to handle a SIGINT
-	// landing between backup_status_start above and this block: the signal
-	// handler would already have taken the has_started=true branch of
-	// backup_status_stop and called init itself. In that case our init returns
-	// false (CAS-lost), backup_state is a valid struct, and we still need to
-	// signal one_shot so cleanup persists what the worker writes on its way
-	// out. Only skip one_shot when state is ABORTED — letting cleanup print
-	// the unrecoverable message.
-	if (backup_status_has_stopped(status) && backup_config_can_resume(conf)) {
-		if (backup_status_get_backup_state(status) == NULL) {
-			backup_status_init_backup_state_file(conf->state_file_dst, status);
-		}
-		if (backup_status_get_backup_state(status) != BACKUP_STATE_ABORTED) {
-			backup_status_signal_one_shot(status);
-		}
-	}
-
 	bool first;
 	// only process indices/udfs if we are not resuming a failed/interrupted backup
 	if (conf->state_file != NULL) {
@@ -945,6 +919,14 @@ cleanup4:
 
 	if (backup_state == BACKUP_STATE_ABORTED) {
 		err("Backup was aborted, meaning the state is unrecoverable");
+	}
+	else if (backup_state == NULL && backup_status_has_stopped(status)) {
+		// SIGINT arrived before backup_status_start() did any real work
+		// (typically during the slow S3 API init). No records were scanned,
+		// no one-shot work was done, and no partial state exists to resume
+		// from. Tell the user clearly so they know to just re-run.
+		inf("Backup was interrupted before any data was scanned; "
+				"no state file was saved. Re-run the same command to retry.");
 	}
 
 cleanup3:
@@ -1489,8 +1471,9 @@ save_job_state(const backup_thread_args_t* args)
 		pthread_mutex_lock(&args->status->stop_lock);
 		backup_state_t* state = backup_status_get_backup_state(args->status);
 
-		// See backup_status_save_scan_state: NULL is reachable if the pre-start
-		// SIGINT path's deferred init hasn't yet produced a state struct.
+		// See backup_status_save_scan_state: NULL is reachable when SIGINT
+		// fires before backup_status_start runs, since backup_status_stop
+		// deliberately leaves backup_state NULL in that case.
 		if (state == NULL || state == BACKUP_STATE_ABORTED) {
 			pthread_mutex_unlock(&args->status->stop_lock);
 			return;

--- a/src/backup.c
+++ b/src/backup.c
@@ -676,13 +676,23 @@ start_backup(backup_config_t* conf)
 	// left backup_state NULL rather than risk a deadlock by opening the state
 	// file from the signal handler. Initialize it now from a safe context so
 	// the worker threads (which are about to be spawned and will see stop=true)
-	// have somewhere to write partition state and so cleanup can emit a usable
-	// resumption file instead of "Backup was aborted, state is unrecoverable".
-	// Also signal one_shot completion: the backup worker won't run far enough
-	// to do it itself, and the save-state path in cleanup is gated on it.
-	if (backup_status_has_stopped(status) && backup_config_can_resume(conf)
-			&& backup_status_get_backup_state(status) == NULL) {
-		if (backup_status_init_backup_state_file(conf->state_file_dst, status)) {
+	// have somewhere to write partition state, and signal one_shot so the
+	// cleanup save-state path (gated on backup_status_one_shot_done) actually
+	// flushes the state file to disk.
+	//
+	// Init and one_shot signaling are kept independent to handle a SIGINT
+	// landing between backup_status_start above and this block: the signal
+	// handler would already have taken the has_started=true branch of
+	// backup_status_stop and called init itself. In that case our init returns
+	// false (CAS-lost), backup_state is a valid struct, and we still need to
+	// signal one_shot so cleanup persists what the worker writes on its way
+	// out. Only skip one_shot when state is ABORTED — letting cleanup print
+	// the unrecoverable message.
+	if (backup_status_has_stopped(status) && backup_config_can_resume(conf)) {
+		if (backup_status_get_backup_state(status) == NULL) {
+			backup_status_init_backup_state_file(conf->state_file_dst, status);
+		}
+		if (backup_status_get_backup_state(status) != BACKUP_STATE_ABORTED) {
 			backup_status_signal_one_shot(status);
 		}
 	}
@@ -1479,7 +1489,9 @@ save_job_state(const backup_thread_args_t* args)
 		pthread_mutex_lock(&args->status->stop_lock);
 		backup_state_t* state = backup_status_get_backup_state(args->status);
 
-		if (state == BACKUP_STATE_ABORTED) {
+		// See backup_status_save_scan_state: NULL is reachable if the pre-start
+		// SIGINT path's deferred init hasn't yet produced a state struct.
+		if (state == NULL || state == BACKUP_STATE_ABORTED) {
 			pthread_mutex_unlock(&args->status->stop_lock);
 			return;
 		}

--- a/src/backup.c
+++ b/src/backup.c
@@ -671,6 +671,22 @@ start_backup(backup_config_t* conf)
 
 	backup_status_start(status);
 
+	// If a stop was requested before backup_status_start ran (typically a
+	// SIGINT during S3 API initialization), backup_status_stop deliberately
+	// left backup_state NULL rather than risk a deadlock by opening the state
+	// file from the signal handler. Initialize it now from a safe context so
+	// the worker threads (which are about to be spawned and will see stop=true)
+	// have somewhere to write partition state and so cleanup can emit a usable
+	// resumption file instead of "Backup was aborted, state is unrecoverable".
+	// Also signal one_shot completion: the backup worker won't run far enough
+	// to do it itself, and the save-state path in cleanup is gated on it.
+	if (backup_status_has_stopped(status) && backup_config_can_resume(conf)
+			&& backup_status_get_backup_state(status) == NULL) {
+		if (backup_status_init_backup_state_file(conf->state_file_dst, status)) {
+			backup_status_signal_one_shot(status);
+		}
+	}
+
 	bool first;
 	// only process indices/udfs if we are not resuming a failed/interrupted backup
 	if (conf->state_file != NULL) {

--- a/src/backup_status.c
+++ b/src/backup_status.c
@@ -626,9 +626,17 @@ backup_status_stop(const backup_config_t* conf, backup_status_t* status)
 		// try initializing the backup file, which may have already been done
 		backup_status_init_backup_state_file(conf->state_file_dst, status);
 	}
-	else {
+	else if (!backup_config_can_resume(conf)) {
+		// No state-file destination: nothing to save, mark aborted so cleanup
+		// reports the backup as unrecoverable.
 		status->backup_state = BACKUP_STATE_ABORTED;
 	}
+	// Else: stop arrived before backup_status_start() ran (e.g. SIGINT during
+	// the slow S3 API init under the newer AWS SDK). We deliberately leave
+	// backup_state NULL: opening the state file here could re-enter S3
+	// initialization and deadlock on s3_init_lock if the signal was delivered
+	// to the main thread. start_backup() picks this case up after S3 setup
+	// finishes and initializes the state file from a safe context.
 
 	// sets the stop variable
 	status->stop = true;

--- a/src/backup_status.c
+++ b/src/backup_status.c
@@ -784,7 +784,12 @@ backup_status_save_scan_state(backup_status_t* status,
 
 	backup_state_t* state = status->backup_state;
 
-	if (state == BACKUP_STATE_ABORTED) {
+	// NULL is reachable when SIGINT fires before backup_status_start runs and
+	// can_resume is true (backup_status_stop deliberately leaves backup_state
+	// NULL in that case; start_backup retries the init from a safe context).
+	// If a worker somehow reaches this point before the late init has run,
+	// there's nothing to record into — return rather than deref.
+	if (state == NULL || state == BACKUP_STATE_ABORTED) {
 		pthread_mutex_unlock(&status->stop_lock);
 		return;
 	}

--- a/src/backup_status.c
+++ b/src/backup_status.c
@@ -622,31 +622,21 @@ backup_status_has_stopped(const backup_status_t* status)
 void
 backup_status_stop(const backup_config_t* conf, backup_status_t* status)
 {
-	if (backup_status_has_started(status) && backup_config_can_resume(conf)
-			&& backup_status_one_shot_done(status)) {
+	if (backup_status_has_started(status) && backup_config_can_resume(conf)) {
 		// try initializing the backup file, which may have already been done
 		backup_status_init_backup_state_file(conf->state_file_dst, status);
 	}
 	else if (!backup_config_can_resume(conf)) {
-		// No state-file destination: nothing to save, mark aborted so cleanup
-		// reports the backup as unrecoverable.
+		// No state-file destination (estimate mode): nothing to save, mark
+		// aborted so cleanup reports the backup as unrecoverable.
 		status->backup_state = BACKUP_STATE_ABORTED;
 	}
-	// Else: stop arrived before any useful work happened — either
-	//   (a) before backup_status_start() ran (typically a SIGINT during the
-	//       slow S3 API init under the newer AWS SDK), or
-	//   (b) after start but before the first worker signaled one_shot_done
-	//       (e.g. a worker's own stop() call after seeing has_stopped=true
-	//       and breaking out of its loop without doing any work).
-	// Leave backup_state NULL deliberately. The save path in cleanup is
-	// gated on one_shot_done, so a state struct created here would never
-	// be flushed to S3 anyway, AND if it were, the resumed backup would
-	// silently skip the one-shot work (indexes, UDFs, META_FIRST_FILE) and
-	// produce output missing that metadata. The cleanup path in start_backup
-	// detects the resulting NULL+stopped state and prints a clear
-	// "interrupted before any data was scanned" message so the user knows
-	// to just re-run, rather than seeing the misleading "state is
-	// unrecoverable" error that BACKUP_STATE_ABORTED would have produced.
+	// Else: stop arrived before backup_status_start() ran — typically a SIGINT
+	// during the slow S3 API init under the newer AWS SDK. Leave backup_state
+	// NULL deliberately. The cleanup path in start_backup detects NULL+stopped
+	// and prints a clear "interrupted before any data was scanned" message so
+	// the user knows to just re-run, rather than seeing the misleading "state
+	// is unrecoverable" error that BACKUP_STATE_ABORTED would have produced.
 
 	// sets the stop variable
 	status->stop = true;

--- a/src/backup_status.c
+++ b/src/backup_status.c
@@ -622,7 +622,8 @@ backup_status_has_stopped(const backup_status_t* status)
 void
 backup_status_stop(const backup_config_t* conf, backup_status_t* status)
 {
-	if (backup_status_has_started(status) && backup_config_can_resume(conf)) {
+	if (backup_status_has_started(status) && backup_config_can_resume(conf)
+			&& backup_status_one_shot_done(status)) {
 		// try initializing the backup file, which may have already been done
 		backup_status_init_backup_state_file(conf->state_file_dst, status);
 	}
@@ -631,12 +632,21 @@ backup_status_stop(const backup_config_t* conf, backup_status_t* status)
 		// reports the backup as unrecoverable.
 		status->backup_state = BACKUP_STATE_ABORTED;
 	}
-	// Else: stop arrived before backup_status_start() ran (e.g. SIGINT during
-	// the slow S3 API init under the newer AWS SDK). We deliberately leave
-	// backup_state NULL: opening the state file here could re-enter S3
-	// initialization and deadlock on s3_init_lock if the signal was delivered
-	// to the main thread. start_backup() picks this case up after S3 setup
-	// finishes and initializes the state file from a safe context.
+	// Else: stop arrived before any useful work happened — either
+	//   (a) before backup_status_start() ran (typically a SIGINT during the
+	//       slow S3 API init under the newer AWS SDK), or
+	//   (b) after start but before the first worker signaled one_shot_done
+	//       (e.g. a worker's own stop() call after seeing has_stopped=true
+	//       and breaking out of its loop without doing any work).
+	// Leave backup_state NULL deliberately. The save path in cleanup is
+	// gated on one_shot_done, so a state struct created here would never
+	// be flushed to S3 anyway, AND if it were, the resumed backup would
+	// silently skip the one-shot work (indexes, UDFs, META_FIRST_FILE) and
+	// produce output missing that metadata. The cleanup path in start_backup
+	// detects the resulting NULL+stopped state and prints a clear
+	// "interrupted before any data was scanned" message so the user knows
+	// to just re-run, rather than seeing the misleading "state is
+	// unrecoverable" error that BACKUP_STATE_ABORTED would have produced.
 
 	// sets the stop variable
 	status->stop = true;
@@ -786,9 +796,9 @@ backup_status_save_scan_state(backup_status_t* status,
 
 	// NULL is reachable when SIGINT fires before backup_status_start runs and
 	// can_resume is true (backup_status_stop deliberately leaves backup_state
-	// NULL in that case; start_backup retries the init from a safe context).
-	// If a worker somehow reaches this point before the late init has run,
-	// there's nothing to record into — return rather than deref.
+	// NULL in that case — see backup_status_stop). Workers normally exit on
+	// has_stopped() before reaching here in that scenario, but treat NULL as
+	// no-op rather than deref it, mirroring the BACKUP_STATE_ABORTED case.
 	if (state == NULL || state == BACKUP_STATE_ABORTED) {
 		pthread_mutex_unlock(&status->stop_lock);
 		return;


### PR DESCRIPTION
This pull request improves the reliability and safety of backup state handling, especially in scenarios where a stop (such as a SIGINT) is requested during S3 API initialization. The main focus is to avoid potential deadlocks and ensure that the backup state is properly initialized and recoverable, even if the backup is interrupted early.

**Backup state handling improvements:**

* In `start_backup`, added logic to safely initialize the backup state file if a stop was requested before backup startup completed, ensuring worker threads have a valid state file and that cleanup can emit a usable resumption file. Also signals one-shot completion in this scenario.
* In `backup_status_stop`, clarified the handling when no state-file destination is configured: explicitly marks the backup as aborted so cleanup reports it as unrecoverable. Added comments explaining why the backup state is left NULL if a stop arrives before backup startup, to avoid deadlocks during S3 initialization.