### PR TITLE
fix: build AWS SDK on macos-26 under Xcode 26.5

### DIFF
--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -109,6 +109,10 @@ jobs:
         # Avoid `brew info | grep -m 1` (broken pipe). Homebrew JSON may be an array or one object.
         CMAKE_VERSION="$(brew info cmake --json=v2 | jq -r '(if type == "array" then .[0] else . end).versions.stable' | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
         echo "CMAKE_VERSION=$CMAKE_VERSION" >> $GITHUB_ENV
+        # Key caches on the Xcode version too: a runner-image Xcode bump (e.g. 26.4 -> 26.5)
+        # changes the toolchain/SDK, so stale cmake build trees must be rebuilt, not reused.
+        XCODE_VERSION="$(xcodebuild -version 2>/dev/null | head -n1 | awk '{print $2}')"
+        echo "XCODE_VERSION=$XCODE_VERSION" >> $GITHUB_ENV
     - name: Cache AWS C++ sdk
       id: cache-aws-sdk-cpp
       uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
@@ -117,7 +121,7 @@ jobs:
         cache-index: "3"
       with:
         path: aws-sdk-cpp-${{ env.AWS_SDK_CPP_VERSION }}
-        key: aws-sdk-cpp-${{ env.cache-index }}-mac-artifact-${{ env.AWS_SDK_CPP_VERSION }}-${{ matrix.os }}-${{ runner.arch }}-cmake-${{ env.CMAKE_VERSION }}
+        key: aws-sdk-cpp-${{ env.cache-index }}-mac-artifact-${{ env.AWS_SDK_CPP_VERSION }}-${{ matrix.os }}-${{ runner.arch }}-cmake-${{ env.CMAKE_VERSION }}-xcode-${{ env.XCODE_VERSION }}
     - name: Download AWS C++ sdk
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       if: steps.cache-aws-sdk-cpp.outputs.cache-hit != 'true'
@@ -140,9 +144,11 @@ jobs:
           -DCMAKE_INSTALL_LIBDIR=lib
           -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         )
-        # Xcode / Clang on macOS 26 treats aws-crt-cpp literal-operator spacing as deprecated (often under -Werror).
+        # Xcode / Clang on macOS 26 (Xcode 26.5+) rejects two things in the AWS SDK under -Werror:
+        # aws-crt-cpp literal-operator spacing (-Wdeprecated-literal-operator) and abs(int64_t) in
+        # AdaptiveRetryStrategy.cpp (-Wabsolute-value). Suppress both so the SDK builds.
         if [[ "${{ matrix.os }}" == "macos-26" ]]; then
-          FLAGS+=(-DCMAKE_CXX_FLAGS=-Wno-deprecated-literal-operator)
+          FLAGS+=(-DCMAKE_CXX_FLAGS="-Wno-deprecated-literal-operator -Wno-absolute-value")
         fi
         cmake -S . -B build_static "${FLAGS[@]}"
         make -C build_static


### PR DESCRIPTION
## Problem

The `Mac Artifact` workflow is failing on `master`. The `macos-26` job is the real failure; `macos-14` / `macos-15-intel` are just canceled by matrix `fail-fast`.

The macos-26 runner image moved to **Xcode 26.5**. The same workflow passed on May 29 (commit #143) and #144 ("Drop support for ubuntu-20.04") changed nothing in the Mac build, so this is an environment regression, not a code change.

AWS SDK C++ `1.11.813` no longer builds under Xcode 26.5 with the current config:

1. The cached AWS SDK cmake `build_static` tree was configured against the previous Xcode SDK. `make install` rebuilds it under the new toolchain, producing libc++ header search-path errors (`<cctype> tried including <ctype.h> but didn't find libc++'s <ctype.h>` ... 11 of these).
2. Xcode 26.5's clang flags `abs(int64_t)` in `AdaptiveRetryStrategy.cpp:80` as `-Werror,-Wabsolute-value`.

The existing `-Wno-deprecated-literal-operator` workaround (#139) only covers an older, separate warning.

## Fix

- Add the Xcode version to the AWS SDK cache key. A toolchain bump now invalidates the stale cache and forces a clean reconfigure + rebuild against the current SDK, which clears the header search-path errors. Also prevents this class of breakage recurring on future image bumps.
- Add `-Wno-absolute-value` alongside the existing `-Wno-deprecated-literal-operator` for the macos-26 SDK build.

## Validation

Draft, pushed to let CI exercise the macos-26 job. If Xcode 26.5 surfaces further `-Werror` warnings beyond these two, we add the matching `-Wno-*` flags.