### PR TITLE
ci: build AWS SDK on macos-26 under Xcode 26.5 in build-and-release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -321,6 +321,10 @@ jobs:
         # Homebrew may emit a JSON array (Linux) or a single formula object (macOS).
         CMAKE_VERSION="$(brew info cmake --json=v2 | jq -r '(if type == "array" then .[0] else . end).versions.stable' | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
         echo "CMAKE_VERSION=$CMAKE_VERSION" >> $GITHUB_ENV
+        # Key caches on the Xcode version too: a runner-image Xcode bump (e.g. 26.4 -> 26.5)
+        # changes the toolchain/SDK, so stale cmake build trees must be rebuilt, not reused.
+        XCODE_VERSION="$(xcodebuild -version 2>/dev/null | head -n1 | awk '{print $2}')"
+        echo "XCODE_VERSION=$XCODE_VERSION" >> $GITHUB_ENV
     - name: Cache AWS C++ sdk
       id: cache-aws-sdk-cpp
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
@@ -329,7 +333,7 @@ jobs:
         cache-index: "3"
       with:
         path: aws-sdk-cpp-${{ env.AWS_SDK_CPP_VERSION }}
-        key: aws-sdk-cpp-${{ env.cache-index }}-mac-artifact-${{ env.AWS_SDK_CPP_VERSION }}-${{ matrix.os }}-${{ runner.arch }}-cmake-${{ env.CMAKE_VERSION }}
+        key: aws-sdk-cpp-${{ env.cache-index }}-mac-artifact-${{ env.AWS_SDK_CPP_VERSION }}-${{ matrix.os }}-${{ runner.arch }}-cmake-${{ env.CMAKE_VERSION }}-xcode-${{ env.XCODE_VERSION }}
     - name: Download AWS C++ sdk
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       if: steps.cache-aws-sdk-cpp.outputs.cache-hit != 'true'
@@ -352,9 +356,11 @@ jobs:
           -DCMAKE_INSTALL_LIBDIR=lib
           -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         )
-        # Xcode / Clang on macOS 26 enables -Wdeprecated-literal-operator as error for aws-crt-cpp 1.x headers.
+        # Xcode / Clang on macOS 26 (Xcode 26.5+) rejects two things in the AWS SDK under -Werror:
+        # aws-crt-cpp literal-operator spacing (-Wdeprecated-literal-operator) and abs(int64_t) in
+        # AdaptiveRetryStrategy.cpp (-Wabsolute-value). Suppress both so the SDK builds.
         if [[ "${{ matrix.os }}" == "macos-26" ]]; then
-          FLAGS+=(-DCMAKE_CXX_FLAGS=-Wno-deprecated-literal-operator)
+          FLAGS+=(-DCMAKE_CXX_FLAGS="-Wno-deprecated-literal-operator -Wno-absolute-value")
         fi
         cmake -S . -B build_static "${FLAGS[@]}"
         make -C build_static


### PR DESCRIPTION
build-and-release.yml carries its own inline copy of the macOS AWS SDK build. The b54c999 fix was only applied to mac-artifact.yml, so the release workflow still broke on the macos-26 runner once its image moved to Xcode 26.5 / AppleClang 21:

- The AWS SDK cache key had no Xcode component, so the Xcode 26.4.1 -> 26.5 image bump reused a stale build_static tree. `sudo make install` then re-ran cmake against absolute Xcode_26.4.1 SDK paths under the 26.5 compiler, producing libc++ header-search-path errors (<cwctype>/<wctype.h> "not configured properly").
- That recompile lacked -Wno-absolute-value, so std::abs(int64_t) in AdaptiveRetryStrategy.cpp tripped -Werror,-Wabsolute-value.

Port the mac-artifact.yml fix: key the cache on XCODE_VERSION (busts stale trees on a toolchain bump) and suppress both -Wabsolute-value and -Wdeprecated-literal-operator for macos-26.