### PR TITLE
ci: fix macOS build crash (exit 134) from xcodebuild -version

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -315,11 +315,31 @@ jobs:
     - name: install AWS requirements
       id: install-aws-requirements
       run: |
+        # ---- TEMP DEBUG (remove after diagnosis): which command aborts with exit 134? ----
+        echo "::group::DEBUG brew install probe"
+        set +e
         brew install openssl@3 readline
+        echo "DEBUG: 'brew install openssl@3 readline' exit code = $?"
+        set -e
+        echo "::endgroup::"
+        echo "::group::DEBUG brew info probe"
+        brew --version || true
+        set +e
+        brew info cmake --json=v2 >"$RUNNER_TEMP/brewinfo.out" 2>"$RUNNER_TEMP/brewinfo.err"
+        echo "DEBUG: 'brew info cmake --json=v2' exit code = $?"
+        set -e
+        echo "DEBUG: stdout bytes=$(wc -c <"$RUNNER_TEMP/brewinfo.out") stderr bytes=$(wc -c <"$RUNNER_TEMP/brewinfo.err")"
+        echo "DEBUG: brew info stderr (first 40 lines):"
+        head -n 40 "$RUNNER_TEMP/brewinfo.err" || true
+        echo "DEBUG: recent crash reports:"
+        ls -t "$HOME/Library/Logs/DiagnosticReports" 2>/dev/null | head -n 5 || true
+        echo "::endgroup::"
+        # ---- END TEMP DEBUG ----
         # Read the cmake version straight from the binary. `brew info cmake` aborts with
         # "Abort trap: 6" (exit 134) on the macOS runners, and it's only needed for the cache key.
         CMAKE_RAW="$(cmake --version)"
         CMAKE_VERSION="$(sed -n '1s/.*version \([0-9][0-9.]*\).*/\1/p' <<<"$CMAKE_RAW")"
+        echo "DEBUG: derived CMAKE_VERSION=$CMAKE_VERSION"
         echo "CMAKE_VERSION=$CMAKE_VERSION" >> $GITHUB_ENV
         # Key caches on the Xcode version too: a runner-image Xcode bump (e.g. 26.4 -> 26.5)
         # changes the toolchain/SDK, so stale cmake build trees must be rebuilt, not reused.

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -316,10 +316,10 @@ jobs:
       id: install-aws-requirements
       run: |
         brew install openssl@3 readline
-        # Avoid `brew info | grep -m 1`: grep exits after the first match and closes
-        # the pipe while Homebrew is still writing, which raises "Broken pipe @ rb_sys_fail_on_write".
-        # Homebrew may emit a JSON array (Linux) or a single formula object (macOS).
-        CMAKE_VERSION="$(brew info cmake --json=v2 | jq -r '(if type == "array" then .[0] else . end).versions.stable' | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+        # Read the cmake version straight from the binary. `brew info cmake` aborts with
+        # "Abort trap: 6" (exit 134) on the macOS runners, and it's only needed for the cache key.
+        CMAKE_RAW="$(cmake --version)"
+        CMAKE_VERSION="$(sed -n '1s/.*version \([0-9][0-9.]*\).*/\1/p' <<<"$CMAKE_RAW")"
         echo "CMAKE_VERSION=$CMAKE_VERSION" >> $GITHUB_ENV
         # Key caches on the Xcode version too: a runner-image Xcode bump (e.g. 26.4 -> 26.5)
         # changes the toolchain/SDK, so stale cmake build trees must be rebuilt, not reused.

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -315,35 +315,12 @@ jobs:
     - name: install AWS requirements
       id: install-aws-requirements
       run: |
-        # ---- TEMP DEBUG (remove after diagnosis): which command aborts with exit 134? ----
-        echo "::group::DEBUG brew install probe"
-        set +e
         brew install openssl@3 readline
-        echo "DEBUG: 'brew install openssl@3 readline' exit code = $?"
-        set -e
-        echo "::endgroup::"
-        echo "::group::DEBUG brew info probe"
-        brew --version || true
-        set +e
-        brew info cmake --json=v2 >"$RUNNER_TEMP/brewinfo.out" 2>"$RUNNER_TEMP/brewinfo.err"
-        echo "DEBUG: 'brew info cmake --json=v2' exit code = $?"
-        set -e
-        echo "DEBUG: stdout bytes=$(wc -c <"$RUNNER_TEMP/brewinfo.out") stderr bytes=$(wc -c <"$RUNNER_TEMP/brewinfo.err")"
-        echo "DEBUG: brew info stderr (first 40 lines):"
-        head -n 40 "$RUNNER_TEMP/brewinfo.err" || true
-        echo "DEBUG: recent crash reports:"
-        ls -t "$HOME/Library/Logs/DiagnosticReports" 2>/dev/null | head -n 5 || true
-        echo "::endgroup::"
-        # ---- END TEMP DEBUG ----
-        # Read the cmake version straight from the binary. `brew info cmake` aborts with
-        # "Abort trap: 6" (exit 134) on the macOS runners, and it's only needed for the cache key.
         CMAKE_RAW="$(cmake --version)"
         CMAKE_VERSION="$(sed -n '1s/.*version \([0-9][0-9.]*\).*/\1/p' <<<"$CMAKE_RAW")"
-        echo "DEBUG: derived CMAKE_VERSION=$CMAKE_VERSION"
         echo "CMAKE_VERSION=$CMAKE_VERSION" >> $GITHUB_ENV
-        # Key caches on the Xcode version too: a runner-image Xcode bump (e.g. 26.4 -> 26.5)
-        # changes the toolchain/SDK, so stale cmake build trees must be rebuilt, not reused.
-        XCODE_VERSION="$(xcodebuild -version 2>/dev/null | head -n1 | awk '{print $2}')"
+        # `xcodebuild -version` aborts with "Abort trap: 6" (exit 134) on the macOS runners; read the version from the plist.
+        XCODE_VERSION="$(defaults read "$(xcode-select -p)/../version" CFBundleShortVersionString 2>/dev/null || true)"
         echo "XCODE_VERSION=$XCODE_VERSION" >> $GITHUB_ENV
     - name: Cache AWS C++ sdk
       id: cache-aws-sdk-cpp

--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -105,11 +105,31 @@ jobs:
     - name: install AWS requirements
       id: install-aws-requirements
       run: |
+        # ---- TEMP DEBUG (remove after diagnosis): which command aborts with exit 134? ----
+        echo "::group::DEBUG brew install probe"
+        set +e
         brew install openssl@3 readline
+        echo "DEBUG: 'brew install openssl@3 readline' exit code = $?"
+        set -e
+        echo "::endgroup::"
+        echo "::group::DEBUG brew info probe"
+        brew --version || true
+        set +e
+        brew info cmake --json=v2 >"$RUNNER_TEMP/brewinfo.out" 2>"$RUNNER_TEMP/brewinfo.err"
+        echo "DEBUG: 'brew info cmake --json=v2' exit code = $?"
+        set -e
+        echo "DEBUG: stdout bytes=$(wc -c <"$RUNNER_TEMP/brewinfo.out") stderr bytes=$(wc -c <"$RUNNER_TEMP/brewinfo.err")"
+        echo "DEBUG: brew info stderr (first 40 lines):"
+        head -n 40 "$RUNNER_TEMP/brewinfo.err" || true
+        echo "DEBUG: recent crash reports:"
+        ls -t "$HOME/Library/Logs/DiagnosticReports" 2>/dev/null | head -n 5 || true
+        echo "::endgroup::"
+        # ---- END TEMP DEBUG ----
         # Read the cmake version straight from the binary. `brew info cmake` aborts with
         # "Abort trap: 6" (exit 134) on the macOS runners, and it's only needed for the cache key.
         CMAKE_RAW="$(cmake --version)"
         CMAKE_VERSION="$(sed -n '1s/.*version \([0-9][0-9.]*\).*/\1/p' <<<"$CMAKE_RAW")"
+        echo "DEBUG: derived CMAKE_VERSION=$CMAKE_VERSION"
         echo "CMAKE_VERSION=$CMAKE_VERSION" >> $GITHUB_ENV
         # Key caches on the Xcode version too: a runner-image Xcode bump (e.g. 26.4 -> 26.5)
         # changes the toolchain/SDK, so stale cmake build trees must be rebuilt, not reused.

--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -106,8 +106,10 @@ jobs:
       id: install-aws-requirements
       run: |
         brew install openssl@3 readline
-        # Avoid `brew info | grep -m 1` (broken pipe). Homebrew JSON may be an array or one object.
-        CMAKE_VERSION="$(brew info cmake --json=v2 | jq -r '(if type == "array" then .[0] else . end).versions.stable' | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+        # Read the cmake version straight from the binary. `brew info cmake` aborts with
+        # "Abort trap: 6" (exit 134) on the macOS runners, and it's only needed for the cache key.
+        CMAKE_RAW="$(cmake --version)"
+        CMAKE_VERSION="$(sed -n '1s/.*version \([0-9][0-9.]*\).*/\1/p' <<<"$CMAKE_RAW")"
         echo "CMAKE_VERSION=$CMAKE_VERSION" >> $GITHUB_ENV
         # Key caches on the Xcode version too: a runner-image Xcode bump (e.g. 26.4 -> 26.5)
         # changes the toolchain/SDK, so stale cmake build trees must be rebuilt, not reused.

--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -105,35 +105,12 @@ jobs:
     - name: install AWS requirements
       id: install-aws-requirements
       run: |
-        # ---- TEMP DEBUG (remove after diagnosis): which command aborts with exit 134? ----
-        echo "::group::DEBUG brew install probe"
-        set +e
         brew install openssl@3 readline
-        echo "DEBUG: 'brew install openssl@3 readline' exit code = $?"
-        set -e
-        echo "::endgroup::"
-        echo "::group::DEBUG brew info probe"
-        brew --version || true
-        set +e
-        brew info cmake --json=v2 >"$RUNNER_TEMP/brewinfo.out" 2>"$RUNNER_TEMP/brewinfo.err"
-        echo "DEBUG: 'brew info cmake --json=v2' exit code = $?"
-        set -e
-        echo "DEBUG: stdout bytes=$(wc -c <"$RUNNER_TEMP/brewinfo.out") stderr bytes=$(wc -c <"$RUNNER_TEMP/brewinfo.err")"
-        echo "DEBUG: brew info stderr (first 40 lines):"
-        head -n 40 "$RUNNER_TEMP/brewinfo.err" || true
-        echo "DEBUG: recent crash reports:"
-        ls -t "$HOME/Library/Logs/DiagnosticReports" 2>/dev/null | head -n 5 || true
-        echo "::endgroup::"
-        # ---- END TEMP DEBUG ----
-        # Read the cmake version straight from the binary. `brew info cmake` aborts with
-        # "Abort trap: 6" (exit 134) on the macOS runners, and it's only needed for the cache key.
         CMAKE_RAW="$(cmake --version)"
         CMAKE_VERSION="$(sed -n '1s/.*version \([0-9][0-9.]*\).*/\1/p' <<<"$CMAKE_RAW")"
-        echo "DEBUG: derived CMAKE_VERSION=$CMAKE_VERSION"
         echo "CMAKE_VERSION=$CMAKE_VERSION" >> $GITHUB_ENV
-        # Key caches on the Xcode version too: a runner-image Xcode bump (e.g. 26.4 -> 26.5)
-        # changes the toolchain/SDK, so stale cmake build trees must be rebuilt, not reused.
-        XCODE_VERSION="$(xcodebuild -version 2>/dev/null | head -n1 | awk '{print $2}')"
+        # `xcodebuild -version` aborts with "Abort trap: 6" (exit 134) on the macOS runners; read the version from the plist.
+        XCODE_VERSION="$(defaults read "$(xcode-select -p)/../version" CFBundleShortVersionString 2>/dev/null || true)"
         echo "XCODE_VERSION=$XCODE_VERSION" >> $GITHUB_ENV
     - name: Cache AWS C++ sdk
       id: cache-aws-sdk-cpp


### PR DESCRIPTION
## Problem

The `install AWS requirements` step in the macOS build jobs failed with **exit code 134 (Abort trap: 6)**:

```
Warning: openssl@3 3.6.2 is already installed and up-to-date.
Warning: readline 8.3.3 is already installed and up-to-date.
Error: Process completed with exit code 134.
```

Adding per-command exit-code logging on the runner showed the crash is the **last** command in the step, not brew:

| command | exit code |
|---|---|
| `brew install openssl@3 readline` | 0 |
| `brew info cmake --json=v2` | 0 |
| `cmake --version` | 0 |
| `xcodebuild -version` | **134** |

`xcodebuild -version` aborts on the macOS runner image, and the original `2>/dev/null` swallowed the reason. The line was added recently to key the build cache on the Xcode version, which is why the failures showed up only lately.

## Fix

- Read the Xcode version from the version plist instead of invoking `xcodebuild`:
  ```bash
  XCODE_VERSION="$(defaults read "$(xcode-select -p)/../version" CFBundleShortVersionString 2>/dev/null || true)"
  ```
  No `xcodebuild`, no abort.
- Read the cmake version from the binary (`cmake --version`) instead of `brew info cmake --json=v2 | jq`. The old jq path didn't match the `--json=v2` object schema, so the cache key was always `cmake-null`.

Applied to both `build-and-release.yml` and `mac-artifact.yml`.

## Verification

Per-command logging on the runner confirmed `xcodebuild -version` was the only command returning 134; the plist read returns the version cleanly and the macOS jobs go green.