### PR TITLE
ci: build EL9/EL10 against oldest-stable OpenSSL to fix dynamic linking

### DIFF
--- a/.github/bin/assert_openssl_floor.sh
+++ b/.github/bin/assert_openssl_floor.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Fail the build if the freshly linked asbackup/asrestore reference any OpenSSL symbol
+# version above the EL9/EL10 GA floor (OPENSSL_3.2.0, from Rocky vault openssl-libs
+# 3.2.2). This is the container-independent backstop for the dynamic-link regression:
+# if the build floats to a newer libcrypto (3.5 -> OPENSSL_3.4.0 symbols, pulled in via
+# the AWS SDK), the binary fails to load on RHEL 9.x/10.0 customers. Checking the
+# dynamic symbol table catches it at build time even for lazily bound symbols that
+# `asbackup --help` never exercises, and it asserts the floor directly instead of just
+# confirming build-env == test-env. No-op on other distros.
+set -euo pipefail
+
+distro="${1:-${ENV_DISTRO:-}}"
+case "$distro" in
+  el9|el10) ;;
+  *) echo "assert_openssl_floor: nothing to check for '${distro:-<unset>}'"; exit 0 ;;
+esac
+
+floor_minor=2   # allow OPENSSL_3.0 .. 3.2; fail on 3.3 and newer
+violations=""
+for bin in bin/asbackup bin/asrestore; do
+  if [[ ! -f "$bin" ]]; then
+    echo "assert_openssl_floor: expected built binary $bin not found" >&2
+    exit 1
+  fi
+  # objdump -T lists the dynamic (undefined) symbols this binary needs from libcrypto/
+  # libssl, versioned as OPENSSL_3.x. awk picks any minor above the floor.
+  bad="$(objdump -T "$bin" \
+    | grep -oE 'OPENSSL_3\.[0-9]+' \
+    | sort -u \
+    | awk -F. -v floor="$floor_minor" '$2 > floor {print}')"
+  if [[ -n "$bad" ]]; then
+    violations+="${bin}:"$'\n'"${bad}"$'\n'
+  fi
+done
+
+if [[ -n "$violations" ]]; then
+  echo "::error::asbackup/asrestore reference OpenSSL symbols above the GA 3.${floor_minor} floor:" >&2
+  printf '%s' "$violations" >&2
+  echo "The EL build floated past the pinned Rocky vault OpenSSL; these binaries will not load on older RHEL ${distro#el}.x." >&2
+  exit 1
+fi
+
+echo "assert_openssl_floor: ${distro} OK (no OpenSSL symbols above 3.${floor_minor})"

--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -382,7 +382,9 @@ function compile_deps_el8() {
 }
 
 function install_deps_el9() {
-  dnf -y update
+  # No `dnf -y update`: the "Pin EL build repos" step froze repos to the Rocky 9.6
+  # vault, so deps install at the GA OpenSSL (3.2.2). Updating would float to 3.5
+  # (OPENSSL_3.4.0 symbols) and break loading on older RHEL 9.x libcrypto.
   dnf -y install $BUILD_DEPS_REDHAT_9 $FPM_DEPS_REDHAT_9
   build_libyaml_static
   gem install fpm -v 1.17.0
@@ -449,7 +451,9 @@ function compile_deps_el9() {
 }
 
 function install_deps_el10() {
-  dnf -y update
+  # No `dnf -y update`: the "Pin EL build repos" step froze repos to the Rocky 10.0
+  # vault, so deps install at the GA OpenSSL (3.2.2). Updating would float to 3.5
+  # (OPENSSL_3.4.0 symbols) and break loading on RHEL 10.0 libcrypto.
   dnf -y install $BUILD_DEPS_REDHAT_10 $FPM_DEPS_REDHAT_10
   build_libyaml_static
   gem install fpm -v 1.17.0

--- a/.github/bin/pin_build_repos.sh
+++ b/.github/bin/pin_build_repos.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Freeze EL9/EL10 to the Rocky vault GA snapshot for the base image's minor, so the
+# dynamically linked OpenSSL floor stays at the oldest the major shipped (3.2.2 ->
+# OPENSSL_3.2.0). The default UBI repos float to 3.5 (9.7/10.1), whose OPENSSL_3.4.0
+# symbols (e.g. EVP_MD_CTX_get_size_ex via the AWS SDK) the older RHEL 9.x/10.0
+# libcrypto can't satisfy. Run as a subprocess (not sourced); no-op on other distros.
+set -euo pipefail
+
+distro="${1:-${ENV_DISTRO:-}}"
+case "$distro" in
+  el9)  rel=9.6  ;;   # match the ubi9:9.6 / ubi10:10.0 base GA (no downgrade)
+  el10) rel=10.0 ;;
+  *)    echo "pin_build_repos: nothing to pin for '${distro:-<unset>}'"; exit 0 ;;
+esac
+
+arch="$(uname -m)"
+base="https://dl.rockylinux.org/vault/rocky/${rel}"
+
+# Replace the floating UBI repos with the frozen vault snapshot. gpgcheck off: official
+# Rocky HTTPS mirrors, and the Rocky keys aren't in a UBI image (as aql/asadm do).
+rm -f /etc/yum.repos.d/*.repo
+: > /etc/yum.repos.d/rocky-vault.repo
+for repo in BaseOS AppStream CRB devel; do
+  name="$(printf '%s' "$repo" | tr '[:upper:]' '[:lower:]')"
+  {
+    printf '[%s]\n' "$name"
+    printf 'name=Rocky Linux %s - %s (vault)\n' "$rel" "$repo"
+    printf 'baseurl=%s/%s/%s/os/\n' "$base" "$repo" "$arch"
+    printf 'gpgcheck=0\n'
+    printf 'enabled=1\n\n'
+  } >> /etc/yum.repos.d/rocky-vault.repo
+done
+
+# Pull OpenSSL back down to the snapshot in case a prior step floated it.
+dnf -y distro-sync openssl openssl-libs 2>/dev/null || true
+
+echo "pin_build_repos: ${distro} pinned to Rocky vault ${rel} (${arch})"

--- a/.github/bin/pin_build_repos.sh
+++ b/.github/bin/pin_build_repos.sh
@@ -35,13 +35,28 @@ for repo in BaseOS AppStream CRB devel; do
   } >> /etc/yum.repos.d/rocky-vault.repo
 done
 
-# Pull OpenSSL back down to the snapshot in case an earlier "Install prereqs" step
-# floated it forward against the still-default UBI repos. This is the only thing that
-# re-establishes the GA floor in the test job, so let it fail loudly (no `2>/dev/null
-# || true`): a silently swallowed sync would leave a refloated OpenSSL in place and
-# turn the regression backstop green against the wrong libcrypto. The post-sync rpm -q
-# records the resolved version so the floor is visible in the job log.
-dnf -y distro-sync openssl openssl-libs
-rpm -q --qf 'pin_build_repos: synced %{NAME} to %{VERSION}-%{RELEASE}\n' openssl-libs
+# Pull OpenSSL down to the GA floor (3.2.x) only if an earlier step floated it past it.
+# A plain distro-sync would force a same-version reinstall even when nothing floated,
+# which on el10 fails on a file conflict: the vault's openssl-libs bundles fips.so, but
+# the ubi10 base splits it into openssl-fips-provider-so. Acting only on a real float
+# avoids that, and the post-check keeps the pin self-verifying: it fails loudly (no
+# `2>/dev/null || true`) rather than leaving a refloated OpenSSL the backstop can't see.
+floor_minor=2
+ver="$(rpm -q --qf '%{VERSION}' openssl-libs)"
+case "$ver" in
+  3.*) minor="${ver#3.}"; minor="${minor%%.*}" ;;
+  *)   echo "pin_build_repos: unexpected openssl-libs version '${ver}'" >&2; exit 1 ;;
+esac
+if [ "$minor" -gt "$floor_minor" ]; then
+  echo "pin_build_repos: openssl-libs ${ver} floated above 3.${floor_minor}; syncing down to the vault"
+  dnf -y distro-sync openssl openssl-libs
+  ver="$(rpm -q --qf '%{VERSION}' openssl-libs)"
+  minor="${ver#3.}"; minor="${minor%%.*}"
+fi
+if [ "$minor" -gt "$floor_minor" ]; then
+  echo "pin_build_repos: openssl-libs still ${ver}, above the 3.${floor_minor} floor" >&2
+  exit 1
+fi
+echo "pin_build_repos: openssl-libs at ${ver} (within the 3.${floor_minor} floor)"
 
 echo "pin_build_repos: ${distro} pinned to Rocky vault ${rel} (${arch})"

--- a/.github/bin/pin_build_repos.sh
+++ b/.github/bin/pin_build_repos.sh
@@ -8,16 +8,19 @@ set -euo pipefail
 
 distro="${1:-${ENV_DISTRO:-}}"
 case "$distro" in
-  el9)  rel=9.6  ;;   # match the ubi9:9.6 / ubi10:10.0 base GA (no downgrade)
-  el10) rel=10.0 ;;
+  el9)  rel=9.6  ;;   # match the ubi9:9.6 base GA (openssl-libs 3.2.2, no downgrade)
+  el10) rel=10.0 ;;   # match the ubi10:10.0 base GA (openssl-libs 3.2.2, no downgrade)
   *)    echo "pin_build_repos: nothing to pin for '${distro:-<unset>}'"; exit 0 ;;
 esac
 
 arch="$(uname -m)"
 base="https://dl.rockylinux.org/vault/rocky/${rel}"
 
-# Replace the floating UBI repos with the frozen vault snapshot. gpgcheck off: official
-# Rocky HTTPS mirrors, and the Rocky keys aren't in a UBI image (as aql/asadm do).
+# Replace the floating UBI repos with the frozen vault snapshot. Keep signature
+# verification on: UBI images don't ship Rocky's keyring, so point dnf at the Rocky
+# release key over HTTPS and let it import on first use. gpgcheck=1 guards against a
+# poisoned mirror/CDN swapping the libcrypto/libssl these binaries link against; HTTPS
+# only authenticates the transport to dl.rockylinux.org, not the package contents.
 rm -f /etc/yum.repos.d/*.repo
 : > /etc/yum.repos.d/rocky-vault.repo
 for repo in BaseOS AppStream CRB devel; do
@@ -26,12 +29,19 @@ for repo in BaseOS AppStream CRB devel; do
     printf '[%s]\n' "$name"
     printf 'name=Rocky Linux %s - %s (vault)\n' "$rel" "$repo"
     printf 'baseurl=%s/%s/%s/os/\n' "$base" "$repo" "$arch"
-    printf 'gpgcheck=0\n'
+    printf 'gpgcheck=1\n'
+    printf 'gpgkey=https://dl.rockylinux.org/pub/rocky/RPM-GPG-KEY-Rocky-%s\n' "${rel%%.*}"
     printf 'enabled=1\n\n'
   } >> /etc/yum.repos.d/rocky-vault.repo
 done
 
-# Pull OpenSSL back down to the snapshot in case a prior step floated it.
-dnf -y distro-sync openssl openssl-libs 2>/dev/null || true
+# Pull OpenSSL back down to the snapshot in case an earlier "Install prereqs" step
+# floated it forward against the still-default UBI repos. This is the only thing that
+# re-establishes the GA floor in the test job, so let it fail loudly (no `2>/dev/null
+# || true`): a silently swallowed sync would leave a refloated OpenSSL in place and
+# turn the regression backstop green against the wrong libcrypto. The post-sync rpm -q
+# records the resolved version so the floor is visible in the job log.
+dnf -y distro-sync openssl openssl-libs
+rpm -q --qf 'pin_build_repos: synced %{NAME} to %{VERSION}-%{RELEASE}\n' openssl-libs
 
 echo "pin_build_repos: ${distro} pinned to Rocky vault ${rel} (${arch})"

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -192,6 +192,10 @@ jobs:
           fetch-tags: true
           submodules: recursive
 
+      # EL9/EL10: build against the oldest-stable (GA) OpenSSL; no-op elsewhere.
+      - name: Pin EL build repos to frozen vault
+        run: bash .github/bin/pin_build_repos.sh "${{ matrix.distro }}"
+
       - name: Install build dependencies
         env:
           ENV_DISTRO: ${{ matrix.distro }}
@@ -627,10 +631,8 @@ jobs:
               ;;
             el*|amzn*)
               command -v dnf >/dev/null || yum install -y dnf
-              # install_deps_* runs `dnf -y update` before linking RPMs; without the same
-              # here, OpenSSL in a cold UBI/AL image can be older than libcrypto symbol
-              # versions the binaries were built against (e.g. OPENSSL_3.4.0).
-              dnf -y update
+              # No `dnf -y update`: the "Pin EL build repos" step makes this test run against
+              # the GA OpenSSL real customers have, so a refloated symbol floor would fail here.
               dnf -y install findutils git ca-certificates tar gzip
               ;;
           esac
@@ -640,6 +642,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+
+      # EL9/EL10: install/run against the same GA OpenSSL the build used; no-op elsewhere.
+      - name: Pin EL build repos to frozen vault
+        run: bash .github/bin/pin_build_repos.sh "${{ matrix.distro }}"
 
       - name: Download signed artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -227,6 +227,11 @@ jobs:
           source .github/bin/build_package.sh
           build_packages
 
+      # Direct backstop for the symbol-floor regression: fail here if the EL9/EL10 build
+      # floated past the pinned GA OpenSSL, rather than at a customer's RHEL. No-op elsewhere.
+      - name: Assert OpenSSL symbol floor
+        run: bash .github/bin/assert_openssl_floor.sh "${{ matrix.distro }}"
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -631,8 +636,10 @@ jobs:
               ;;
             el*|amzn*)
               command -v dnf >/dev/null || yum install -y dnf
-              # No `dnf -y update`: the "Pin EL build repos" step makes this test run against
-              # the GA OpenSSL real customers have, so a refloated symbol floor would fail here.
+              # No `dnf -y update` here. This step runs before checkout against the default
+              # UBI repos, so this install may float openssl-libs forward; the later "Pin EL
+              # build repos" step then distro-syncs it back to the GA OpenSSL real customers
+              # have. Adding an update would refloat it and mask a symbol-floor regression.
               dnf -y install findutils git ca-certificates tar gzip
               ;;
           esac

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -111,6 +111,11 @@ jobs:
           source .github/bin/build_package.sh
           build_packages
 
+      # Per-commit backstop for the EL10 symbol-floor regression (the release workflow
+      # covers EL9 too); fails if the build floated past the pinned GA OpenSSL. No-op elsewhere.
+      - name: Assert OpenSSL symbol floor
+        run: bash .github/bin/assert_openssl_floor.sh "${{ matrix.distro }}"
+
       - name: Verify .${{ matrix.pkg }} produced
         run: |
           set -euo pipefail

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -71,6 +71,10 @@ jobs:
       - name: Mark workspace as safe (for git inside container)
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      # EL9/EL10: build against the oldest-stable (GA) OpenSSL; no-op elsewhere.
+      - name: Pin EL build repos to frozen vault
+        run: bash .github/bin/pin_build_repos.sh "${{ matrix.distro }}"
+
       - name: Install build dependencies
         env:
           ENV_DISTRO: ${{ matrix.distro }}


### PR DESCRIPTION
## Problem

On RHEL 9 / RHEL 10, `asbackup`/`asrestore` failed:

```
/usr/bin/asbackup: /lib64/libcrypto.so.3: version `OPENSSL_3.4.0' not found (required by /usr/bin/asbackup)
asbackup: symbol lookup error: asbackup: undefined symbol: EVP_MD_CTX_get_size_ex, version OPENSSL_3.4.0   # at S3 init
```

`asbackup` links `libcrypto`/`libssl` **dynamically** on EL. The build ran `dnf -y update`, which floated OpenSSL to 3.5 (RHEL rebased 3.0 → 3.5 in 9.7 / 10.1), so the AWS SDK's `aws-c-cal` recorded `OPENSSL_3.4.0` symbol dependencies (`EVP_MD_CTX_get_size_ex`) that the older system `libcrypto` on RHEL 9.x / 10.0 can't satisfy. The test job hid the regression by also running `dnf -y update`.

## Fix

Keep the bindings dynamic, but build against the **oldest-stable (GA) OpenSSL** so the symbol floor is the lowest the major shipped.

This pin is **new to the tools suite**, not an existing convention. `aql`/`asadm` reference the Rocky vault only to pull individual RPMs by URL, and they run `dnf -y update` (floating OpenSSL up rather than pinning it). The reason asbackup needs the pin and they don't is asbackup-specific: it statically links the AWS SDK (`aws-c-cal`), which binds newer `OPENSSL_3.4.0` symbols that `aql`/`asadm` never pull in. What this PR does share with the siblings is the UBI base images (`ubi9:9.6`, `ubi10:10.0`) and the 9.6 / 10.0 minor pairing.

- New `.github/bin/pin_build_repos.sh` freezes EL9/EL10 to the Rocky vault GA snapshot matching the UBI base (9.6 / 10.0) → GA OpenSSL **3.2.2**, floor `OPENSSL_3.2.0`. Package signatures are verified against the Rocky release key fetched over HTTPS (`gpgcheck=1`), since UBI images don't ship Rocky's keyring. No-op on other distros.
- The OpenSSL `distro-sync` fails loudly (no `2>/dev/null || true`): a blocked or failed downgrade stops the job instead of silently leaving a refloated OpenSSL and a falsely-green backstop.
- Removed `dnf -y update` from `install_deps_el9` / `install_deps_el10` and from the install-test prereqs, so the test runs against the GA `libcrypto` real customers have.
- New `.github/bin/assert_openssl_floor.sh` is a container-independent backstop: it inspects the built binary's dynamic symbol table (`objdump -T`) and fails the build if any referenced OpenSSL symbol version exceeds `OPENSSL_3.2.0`. This catches lazily bound symbols that `asbackup --help` never exercises. Wired into the build job (EL9/EL10) and `build-check` (EL10 per-commit).

Result: binaries require ≤ `OPENSSL_3.2.0` and load on all RHEL 9.4+ / 10.x.

## Testing

- [ ] Dispatch **Build and Release** with `release=false` (dry-run) on this branch and confirm the el9/el10 build + install-test pass on amd64 and arm64.
- The `assert_openssl_floor.sh` step enforces the symbol floor at build time, so a refloat fails CI directly rather than only at a customer's RHEL.

## Notes

- Floor is `OPENSSL_3.2.0` (covers RHEL 9.4+ and all 10.x). RHEL **9.0-9.3** (OpenSSL 3.0) would require pinning el9 to the Rocky vault **9.0** snapshot, which forces a downgrade on the 9.6 base or a 9.0 base image. Not included here; can add if needed.
- `el8` (OpenSSL 1.1.1, different SONAME) and `amzn2023` are unchanged.
- Per-commit `build-check` covers EL10 (not EL9); EL9 is exercised by the full Build and Release workflow.
