### PR TITLE
ci: key mac asbackup build cache on the release VERSION

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -480,7 +480,10 @@ jobs:
       with:
         path: |
           asbackup/binaries
-        key: ${{ env.cache-name }}-${{ env.cache-index }}-${{ matrix.os }}-${{ runner.arch }}-${{ steps.system-info.outputs.release }}-${{ env.AWS_SDK_CPP_VERSION }}-${{ env.ZSTD_VERSION }}-${{ steps.tag.outputs.tag }}
+        # VERSION must be in the key: binaries bake TOOL_VERSION from $VERSION, and
+        # keying on describe alone let a release reuse mac-artifact.yml's cached
+        # describe-versioned binaries (4.5.7 pkg shipped reporting 4.5.6).
+        key: ${{ env.cache-name }}-${{ env.cache-index }}-${{ matrix.os }}-${{ runner.arch }}-${{ steps.system-info.outputs.release }}-${{ env.AWS_SDK_CPP_VERSION }}-${{ env.ZSTD_VERSION }}-${{ steps.tag.outputs.tag }}-${{ needs.get-version.outputs.VERSION }}
     - name: Install AWS C++ sdk static library
       if: steps.cache-asbackup.outputs.cache-hit != 'true'
       run: |
@@ -511,6 +514,22 @@ jobs:
         set -euo pipefail
         mkdir -p bin
         cp -f binaries/static_bin/asbackup binaries/static_bin/asrestore bin/
+
+    # Guard against stale cached binaries ending up in the pkg.
+    - name: Assert binaries report the release version
+      working-directory: asbackup
+      env:
+        VERSION: ${{ needs.get-version.outputs.VERSION }}
+      run: |
+        set -euo pipefail
+        base="${VERSION%%-*}"
+        for bin in asbackup asrestore; do
+          out=$("./bin/${bin}" --version)
+          echo "${out}" | grep -qF "Version ${base}" || {
+            echo "::error::${bin} reports the wrong version (expected ${base}): ${out}" >&2
+            exit 1
+          }
+        done
 
     - name: Create .pkg
       working-directory: asbackup


### PR DESCRIPTION
## Problem

The 4.5.7 release shipped mac .pkg artifacts whose `asbackup`/`asrestore` report `Version 4.5.6, Build gc7a6d5f65`. This failed the aerospike-tools bundle version check on macos-14 ([failing job](https://github.com/citrusleaf/aerospike-tools/actions/runs/29545735203/job/87779257712)).

Root cause, from release run [29541556325](https://github.com/aerospike/aerospike-tools-backup/actions/runs/29541556325):

1. The release flow builds first and creates the git tag last, so during the build `git describe` at the release commit resolves to `4.5.6-12-gc7a6d5f65`.
2. `build-mac-artifacts` keys its binary cache on that describe output.
3. The push-triggered `mac-artifact.yml` had already built at the same commit **without** `VERSION` set, so the Makefile fell back to `git describe` and baked `4.5.6-12-gc7a6d5f65` into `TOOL_VERSION`, then cached those binaries under the identical key.
4. The release run cache-hit, skipped its own (correctly versioned) build step, and packaged the stale binaries as 4.5.7.

Linux builds were unaffected (no binary cache).

## Fix

- Append the workflow-computed `VERSION` to the `cache-asbackup` key so release builds can never reuse binaries compiled with a different `TOOL_VERSION`.
- Add an assertion step that the staged binaries self-report the release version before the .pkg is created, so any future variant of this fails the build instead of shipping.