### PR TITLE
ci: make release tag creation idempotent for re-runs

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1023,7 +1023,12 @@ jobs:
           set -euo pipefail
           git fetch --tags --force
           if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
-            echo "::error::Tag '${VERSION}' already exists. Bump VERSION first." >&2
+            existing=$(git rev-parse "refs/tags/${VERSION}^{commit}")
+            if [[ "${existing}" == "${GITHUB_SHA}" ]]; then
+              echo "Tag '${VERSION}' already exists at ${GITHUB_SHA}; nothing to do."
+              exit 0
+            fi
+            echo "::error::Tag '${VERSION}' already exists at ${existing}, not ${GITHUB_SHA}. Bump VERSION first." >&2
             exit 1
           fi
           git config user.name  "github-actions[bot]"


### PR DESCRIPTION
Re-running "Build and Release" on master for a version whose tag already exists fails at "Create and push tag", even when the tag points at the exact commit being rebuilt. That blocks legitimate re-runs, like rebuilding the 4.5.7 artifacts after the mac cache poisoning (#161) with no version bump.

Now the step succeeds as a no-op when the existing tag points at `GITHUB_SHA`, and still fails when the tag exists on a different commit (genuine version reuse, needs a VERSION bump).