### PR TITLE
fix(pkg): self-contained airgap-safe packages; dynamic-dep allowlist guard

### DIFF
--- a/.github/bin/build_package.sh
+++ b/.github/bin/build_package.sh
@@ -2,6 +2,36 @@
 set -xeuo pipefail
 
 alias make='make -j8'
+
+function assert_dynamic_deps() {
+  local allowed="libc.so.6 libm.so.6 libpthread.so.0 libdl.so.2 librt.so.1
+    libgcc_s.so.1 libstdc++.so.6 libz.so.1 ld-linux-x86-64.so.2 ld-linux-aarch64.so.1"
+  case "$ENV_DISTRO" in
+    el8)
+      allowed+=" libcurl.so.4 libssl.so.1.1 libcrypto.so.1.1 libzstd.so.1"
+      ;;
+    el9|el10|amzn2023)
+      allowed+=" libcurl.so.4 libssl.so.3 libcrypto.so.3 libzstd.so.1"
+      ;;
+    ubuntu26.04)
+      allowed+=" libjitterentropy.so.3"
+      ;;
+  esac
+
+  local bin lib needed fail=0
+  for bin in asbackup asrestore; do
+    needed=$(readelf -d "bin/$bin" | awk '/\(NEEDED\)/ { gsub(/[][]/, "", $NF); print $NF }')
+    echo "$bin DT_NEEDED:" $needed
+    for lib in $needed; do
+      if ! printf '%s\n' $allowed | grep -qxF "$lib"; then
+        echo "$bin has unexpected dynamic dependency $lib; link it statically or add it to the allowlist and the package depends" >&2
+        fail=1
+      fi
+    done
+  done
+  return $fail
+}
+
 function build_packages(){
 
   if [ "${ENV_DISTRO:-}" = "" ]; then
@@ -33,12 +63,7 @@ function build_packages(){
     make EVENT_LIB=libuv ZSTD_STATIC_PATH=/usr/lib/$ARCH-linux-gnu AWS_SDK_STATIC_PATH=/usr/local/lib CURL_STATIC_PATH=/usr/local/lib OPENSSL_STATIC_PATH=/usr/lib/$ARCH-linux-gnu AWS_SDK_STATIC_PATH=/usr/local/lib JANSSON_STATIC_PATH=/usr/lib/$ARCH-linux-gnu LIBUV_STATIC_PATH=/usr/local/lib
   fi
 
-  for bin in asbackup asrestore; do
-    if ldd "bin/$bin" | grep libuv; then
-      echo "$bin dynamically links libuv; packages must ship a static-libuv binary" >&2
-      return 1
-    fi
-  done
+  assert_dynamic_deps
 
   cd $PKG_DIR
   echo "building package for $BUILD_DISTRO"

--- a/.github/bin/build_package.sh
+++ b/.github/bin/build_package.sh
@@ -33,6 +33,13 @@ function build_packages(){
     make EVENT_LIB=libuv ZSTD_STATIC_PATH=/usr/lib/$ARCH-linux-gnu AWS_SDK_STATIC_PATH=/usr/local/lib CURL_STATIC_PATH=/usr/local/lib OPENSSL_STATIC_PATH=/usr/lib/$ARCH-linux-gnu AWS_SDK_STATIC_PATH=/usr/local/lib JANSSON_STATIC_PATH=/usr/lib/$ARCH-linux-gnu LIBUV_STATIC_PATH=/usr/local/lib
   fi
 
+  for bin in asbackup asrestore; do
+    if ldd "bin/$bin" | grep libuv; then
+      echo "$bin dynamically links libuv; packages must ship a static-libuv binary" >&2
+      return 1
+    fi
+  done
+
   cd $PKG_DIR
   echo "building package for $BUILD_DISTRO"
 

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -65,7 +65,7 @@ rpm: prep
 		--name $(NAME) \
 		--version $(RPM_VERSION) \
 		--maintainer $(MAINTAINER) \
-		--depends "openssl" \
+		--depends "openssl-libs" \
 		--description $(DESCRIPTION) \
 		--license $(LICENSE) \
 		--url $(URL) \

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -43,7 +43,6 @@ deb: prep
 		--name $(NAME) \
 		--version $(VERSION) \
 		--maintainer $(MAINTAINER) \
-		--depends "libuv1" \
 		$(DEB_EXTRA_DEPENDS) \
 		--description $(DESCRIPTION) \
 		--license $(LICENSE) \
@@ -66,7 +65,6 @@ rpm: prep
 		--name $(NAME) \
 		--version $(RPM_VERSION) \
 		--maintainer $(MAINTAINER) \
-		--depends "libuv" \
 		--depends "openssl" \
 		--description $(DESCRIPTION) \
 		--license $(LICENSE) \


### PR DESCRIPTION
## Problem

Installing the standalone `aerospike-asbackup` package on an airgapped system fails with:

```
deb: aerospike-asbackup : missing libuv1
rpm: aerospike-asbackup : missing libuv
```

Since TOOLS-3599 (#139) every Linux packaging build links libuv statically (`build_package.sh` passes `LIBUV_STATIC_PATH=/usr/local/lib`, pointing at the libuv.a built from source in `compile_deps_*`), but the deb still declared `--depends "libuv1"` and the rpm `--depends "libuv"`. On connected systems the package manager silently installs an unneeded library; on airgapped systems the install fails on a dependency the binaries no longer have. 4.5.6 and 4.5.7 both shipped with the stale metadata.

Counterpart of aerospike/aql#84 (same bug class with readline there).

## Changes

- **pkg/Makefile**
  - deb: drop `--depends "libuv1"`.
  - rpm: drop `--depends "libuv"`; change `--depends "openssl"` to `--depends "openssl-libs"` (binaries need libssl/libcrypto, not the openssl CLI; minimal hosts may not have the `openssl` package).
- **.github/bin/build_package.sh**: `assert_dynamic_deps` gate before packaging. Dumps `DT_NEEDED` of `asbackup`/`asrestore` and fails on anything outside a per-distro allowlist (glibc family, libstdc++/libgcc_s, zlib, plus distro OpenSSL/libcurl/libzstd on EL/amzn and libjitterentropy on ubuntu26.04). Catches both a static lib silently going dynamic (this bug) and a new dynamic dep nobody declared (the inverse bug).

## Per-distro state (full release matrix audit)

| Build env | libuv linkage | dynamic deps beyond glibc/libstdc++/zlib |
|---|---|---|
| debian 11/12/13, ubuntu 22.04/24.04 (x86_64 + aarch64) | static, v1.43.0 source-built via `LIBUV_STATIC_PATH` | none (openssl/curl/zstd/jansson/yaml all static) |
| ubuntu 26.04 | static, v1.43.0 | libjitterentropy.so.3 (declared) |
| el8 (x86_64 + aarch64) | static, v1.42.0 | libssl.so.1.1/libcrypto.so.1.1, libcurl.so.4, libzstd.so.1 |
| el9, el10, amzn2023 (x86_64 + aarch64) | static, v1.42.0 | libssl.so.3/libcrypto.so.3, libcurl.so.4, libzstd.so.1 |
| macOS 14/15/26 | static, brew libuv.a via `LIBUV_STATIC_PATH` | n/a (.pkg has no dep metadata) |

EL dynamic OpenSSL is intentional (distro patches it, FIPS story stays clean) and now correctly declared as `openssl-libs`. libcurl/libzstd/zlib are present on any rpm/dnf-based system (rpm and dnf themselves require them), so they stay undeclared, consistent with prior releases.

## Verification

- Allowlist guard logic tested against real ELF binaries in a debian container: correctly flags an unexpected `DT_NEEDED` (libselinux) and passes glibc-only binaries.
- Dry-run dispatch of Build and Release on this branch (release=false): guard runs in every matrix job; per-distro packages inspected for Depends/Requires and `DT_NEEDED` (results posted below when the run completes).

## Workaround for existing 4.5.6/4.5.7 packages on airgapped hosts

The shipped binaries do not need libuv, only the metadata claims it:

```bash
sudo dpkg -i --ignore-depends=libuv1 aerospike-asbackup_4.5.7_<distro>_<arch>.deb
sudo rpm -i --nodeps aerospike-asbackup-4.5.7.<distro>.<arch>.rpm
```