### PR TITLE
fix(pkg): add -1 release iteration to deb/rpm package names

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -691,7 +691,7 @@ jobs:
           case "${{ matrix.distro }}" in
             ubuntu*|debian*)
               export DEBIAN_FRONTEND=noninteractive
-              pkg=$(find ./packages -name "*_${{ matrix.distro }}_*${arch}*.deb" | head -1)
+              pkg=$(find ./packages -name "*${{ matrix.distro }}_*${arch}*.deb" | head -1)
               [[ -n "${pkg}" ]] || { echo "ERROR: no .deb found for ${{ matrix.distro }}/${arch}" >&2; exit 1; }
               apt-get install -y "${pkg}"
               echo "ASTOOLS_REINSTALL=dpkg -i ${pkg}" >> "$GITHUB_ENV"

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -377,8 +377,8 @@ function generate_bake() {
 #   LOCAL_PKGS_COPIED           (paths to clean up on EXIT)
 # ---------------------------------------------------------------------------
 function resolve_packages() {
-  local pkg_amd64="aerospike-asbackup_${VERSION}-1_ubuntu24.04_x86_64.deb"
-  local pkg_arm64="aerospike-asbackup_${VERSION}-1_ubuntu24.04_aarch64.deb"
+  local pkg_amd64="aerospike-asbackup_${VERSION}-1ubuntu24.04_x86_64.deb"
+  local pkg_arm64="aerospike-asbackup_${VERSION}-1ubuntu24.04_aarch64.deb"
   local pool="${DEB_BASE_URL}/pool/${UBUNTU_CODENAME}/aerospike-asbackup"
 
   ASBACKUP_AMD64_URL="${pool}/${pkg_amd64}"

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -377,8 +377,8 @@ function generate_bake() {
 #   LOCAL_PKGS_COPIED           (paths to clean up on EXIT)
 # ---------------------------------------------------------------------------
 function resolve_packages() {
-  local pkg_amd64="aerospike-asbackup_${VERSION}_ubuntu24.04_x86_64.deb"
-  local pkg_arm64="aerospike-asbackup_${VERSION}_ubuntu24.04_aarch64.deb"
+  local pkg_amd64="aerospike-asbackup_${VERSION}-1_ubuntu24.04_x86_64.deb"
+  local pkg_arm64="aerospike-asbackup_${VERSION}-1_ubuntu24.04_aarch64.deb"
   local pool="${DEB_BASE_URL}/pool/${UBUNTU_CODENAME}/aerospike-asbackup"
 
   ASBACKUP_AMD64_URL="${pool}/${pkg_amd64}"

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -10,6 +10,8 @@ MAC_DOC_DIR = /usr/local/aerospike/doc/$(PACKAGE_NAME)
 PACKAGE_NAME = asbackup
 VERSION ?= $(shell git describe --tags --always --abbrev=9)
 RPM_VERSION := $(subst -,_,$(VERSION))
+# rpm Release / deb revision: the "-1" after the version in package names.
+ITERATION ?= 1
 BUILD_DISTRO ?= $(shell $(PKG_DIR)/../.github/bin/os_version.sh)
 # ubuntu26.04 only (BUILD_DISTRO substring match): binaries link libjitterentropy; declare runtime dep.
 DEB_EXTRA_DEPENDS :=
@@ -42,6 +44,7 @@ deb: prep
 		--chdir $(BUILD_DIR)/ \
 		--name $(NAME) \
 		--version $(VERSION) \
+		--iteration $(ITERATION) \
 		--maintainer $(MAINTAINER) \
 		$(DEB_EXTRA_DEPENDS) \
 		--description $(DESCRIPTION) \
@@ -50,7 +53,7 @@ deb: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
-		--package $(TARGET_DIR)/$(NAME)_$(VERSION)_$(BUILD_DISTRO)_$(ARCH).deb
+		--package $(TARGET_DIR)/$(NAME)_$(VERSION)-$(ITERATION)_$(BUILD_DISTRO)_$(ARCH).deb
 
 .PHONY: rpm
 rpm: prep
@@ -64,6 +67,7 @@ rpm: prep
 		--chdir $(BUILD_DIR)/ \
 		--name $(NAME) \
 		--version $(RPM_VERSION) \
+		--iteration $(ITERATION) \
 		--maintainer $(MAINTAINER) \
 		--depends "openssl-libs" \
 		--description $(DESCRIPTION) \
@@ -72,7 +76,7 @@ rpm: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
-		--package $(TARGET_DIR)/$(NAME)-$(RPM_VERSION).$(BUILD_DISTRO).$(ARCH).rpm
+		--package $(TARGET_DIR)/$(NAME)-$(RPM_VERSION)-$(ITERATION).$(BUILD_DISTRO).$(ARCH).rpm
 
 .PHONY: tar
 tar: prep

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -10,8 +10,10 @@ MAC_DOC_DIR = /usr/local/aerospike/doc/$(PACKAGE_NAME)
 PACKAGE_NAME = asbackup
 VERSION ?= $(shell git describe --tags --always --abbrev=9)
 RPM_VERSION := $(subst -,_,$(VERSION))
-# rpm Release / deb revision: the "-1" after the version in package names.
+# rpm Release / deb revision. The deb revision embeds the distro per Debian
+# convention (e.g. 5.0.3-1debian12), like the rpm dist tag.
 ITERATION ?= 1
+DEB_ITERATION = $(ITERATION)$(BUILD_DISTRO)
 BUILD_DISTRO ?= $(shell $(PKG_DIR)/../.github/bin/os_version.sh)
 # ubuntu26.04 only (BUILD_DISTRO substring match): binaries link libjitterentropy; declare runtime dep.
 DEB_EXTRA_DEPENDS :=
@@ -44,7 +46,7 @@ deb: prep
 		--chdir $(BUILD_DIR)/ \
 		--name $(NAME) \
 		--version $(VERSION) \
-		--iteration $(ITERATION) \
+		--iteration $(DEB_ITERATION) \
 		--maintainer $(MAINTAINER) \
 		$(DEB_EXTRA_DEPENDS) \
 		--description $(DESCRIPTION) \
@@ -53,7 +55,7 @@ deb: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
-		--package $(TARGET_DIR)/$(NAME)_$(VERSION)-$(ITERATION)_$(BUILD_DISTRO)_$(ARCH).deb
+		--package $(TARGET_DIR)/$(NAME)_$(VERSION)-$(DEB_ITERATION)_$(ARCH).deb
 
 .PHONY: rpm
 rpm: prep


### PR DESCRIPTION
## What

Adds a package release iteration (`-1`) after the version in .deb/.rpm artifact names, matching the server convention (`aerospike-server-community-8.1.3.0-66.amzn2023.aarch64.rpm`).

| Artifact | Before | After |
|---|---|---|
| rpm | `aerospike-asbackup-4.5.8.el8.x86_64.rpm` | `aerospike-asbackup-4.5.8-1.el8.x86_64.rpm` |
| deb | `aerospike-asbackup_4.5.8_ubuntu24.04_x86_64.deb` | `aerospike-asbackup_4.5.8-1_ubuntu24.04_x86_64.deb` |

## How

- `pkg/Makefile`: new `ITERATION ?= 1`, passed to fpm as `--iteration` and appended in the `--package` filenames.
- rpm: metadata already carried `Release: 1` (fpm default), so only the filename changes.
- deb: control `Version` becomes `4.5.8-1` (proper Debian revision, sorts above the bare `4.5.8`).
- `docker/docker-build.sh`: the released deb it resolves by name gains the `-1`.
- tar and macOS .pkg names are unchanged (no revision concept there).

## Verification

- `make -n` dry runs expand to `aerospike-asbackup_X.Y.Z-1_<distro>_<arch>.deb` and `aerospike-asbackup-X.Y.Z-1.<distro>.<arch>.rpm`; rc versions expand to `X.Y.Z-rc1-1` (deb) / `X.Y.Z_rc1-1` (rpm).
- CI test-install globs (`*_<distro>_*<arch>*.deb`, `*.<distro>.*<arch>*.rpm`) already match the new names, no workflow change needed.

## Coordination

The aerospike-tools bundle downloads per-tool packages from JFrog by name; its companion PR updates those globs with a fallback so bundle builds work with tool versions released before or after this change. Bundle picks up the new names once a release is cut from this branch's repo.
