### PR TITLE
fix(pkg): named conflicts with the aerospike-tools bundle via a version bound and a virtual token

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -578,16 +578,21 @@ jobs:
     needs:
       - get-version
       - organize-built-artifacts
-    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-mac-artifacts.yaml@v3.6.0
+    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-mac-artifacts.yaml@v3.7.0
     permissions:
       contents: read
       id-token: write
     with:
       gh-unsigned-artifacts: unsigned-artifacts-${{ needs.get-version.outputs.VERSION }}
-      artifact-glob: "**/*.pkg"
+      # As observed in shared-workflows v3.7.0: matches_glob() is a bash `case`
+      # match, not a real globstar matcher, so "**/*.pkg" requires a literal "/"
+      # and never matches our flat artifact tree -- every pkg gets skipped and
+      # the job still exits 0. Do not "fix" this back to "**/*.pkg" unless the
+      # pinned signer above implements real globstar matching.
+      artifact-glob: "*.pkg"
       signing-identity: "Developer ID Application: Aerospike, Inc. (22224RFU67)"
       installer-identity: "Developer ID Installer: Aerospike, Inc. (22224RFU67)"
-      gh-workflows-ref: "v3.6.0"
+      gh-workflows-ref: "v3.7.0"
       gh-retention-days: 1
     secrets:
       apple-application-cert: ${{ secrets.APPLE_APPLICATION_CERT }}
@@ -601,11 +606,11 @@ jobs:
     needs:
       - get-version
       - notarize-mac-artifacts
-    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-artifacts.yaml@v3.6.0
+    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-artifacts.yaml@v3.7.0
     with:
       gh-artifact-name: signed-artifacts-${{ needs.get-version.outputs.VERSION }}
       gh-unsigned-artifacts: unsigned-artifacts-${{ needs.get-version.outputs.VERSION }}
-      gh-workflows-ref: "v3.6.0"
+      gh-workflows-ref: "v3.7.0"
     secrets:
       gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
       gpg-public-key: ${{ secrets.GPG_PUBLIC_KEY }}
@@ -808,7 +813,7 @@ jobs:
     needs:
       - get-version
       - organize-signed-artifacts
-    uses: aerospike/shared-workflows/.github/workflows/reusable_deploy-artifacts.yaml@v3.6.0
+    uses: aerospike/shared-workflows/.github/workflows/reusable_deploy-artifacts.yaml@v3.7.0
     with:
       jf-project: database
       jf-build-name: "aerospike-asbackup"
@@ -820,7 +825,7 @@ jobs:
       dry-run: ${{ inputs.release != true }}
       jf-build-id: ${{ needs.get-version.outputs.VERSION }}
       jf-metadata-build-id: ${{ needs.get-version.outputs.VERSION }}-metadata
-      gh-workflows-ref: "v3.6.0"
+      gh-workflows-ref: "v3.7.0"
 
   docker-build-arch:
     name: Docker build, test & push (${{ matrix.arch }})
@@ -1017,7 +1022,7 @@ jobs:
       - get-version
       - upload-artifacts-to-jfrog
       - docker-manifest
-    uses: aerospike/shared-workflows/.github/workflows/reusable_create-release-bundle.yaml@v3.6.0
+    uses: aerospike/shared-workflows/.github/workflows/reusable_create-release-bundle.yaml@v3.7.0
     with:
       jf-project: "database"
       jf-build-names: "aerospike-asbackup:${{ needs.get-version.outputs.VERSION }},aerospike-asbackup-docker:${{ needs.get-version.outputs.VERSION }}"
@@ -1025,7 +1030,7 @@ jobs:
       oidc-provider-name: database-gh-aerospike
       oidc-audience: database-gh-aerospike
       version: ${{ needs.get-version.outputs.VERSION }}
-      gh-workflows-ref: v3.6.0
+      gh-workflows-ref: v3.7.0
       dry-run: false
 
   # Tag-last: created only after every publish step succeeds. A failure

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -37,6 +37,10 @@ MAC_PKG = $(TARGET_DIR)/aerospike-asbackup-$(MAC_VERSION)-$(ARCH).pkg
 .PHONY: all
 all: deb rpm tar
 
+# The aerospike-tools bundle ships these same /opt/aerospike/bin paths. deb
+# Replaces (without Conflicts) lets dpkg hand file ownership to this package;
+# rpm has no equivalent, so Conflicts turns an opaque file-conflict error into
+# an actionable one.
 .PHONY: deb
 deb: prep
 	fpm --force \
@@ -55,6 +59,7 @@ deb: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
+		--replaces "aerospike-tools" \
 		--package $(TARGET_DIR)/$(NAME)_$(VERSION)-$(DEB_ITERATION)_$(ARCH).deb
 
 .PHONY: rpm
@@ -78,6 +83,7 @@ rpm: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
+		--conflicts "aerospike-tools" \
 		--package $(TARGET_DIR)/$(NAME)-$(RPM_VERSION)-$(ITERATION).$(BUILD_DISTRO).$(ARCH).rpm
 
 .PHONY: tar

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -37,10 +37,15 @@ MAC_PKG = $(TARGET_DIR)/aerospike-asbackup-$(MAC_VERSION)-$(ARCH).pkg
 .PHONY: all
 all: deb rpm tar
 
-# The aerospike-tools bundle ships these same /opt/aerospike/bin paths. deb
-# Replaces (without Conflicts) lets dpkg hand file ownership to this package;
-# rpm has no equivalent, so Conflicts turns an opaque file-conflict error into
-# an actionable one.
+# aerospike-tools older than TOOLS_SPLIT_VERSION is the monolithic bundle that
+# ships these same /opt/aerospike/bin paths. From TOOLS_SPLIT_VERSION on it is
+# a transitional metapackage that ships no binaries and Depends on this package
+# instead. Versioned Breaks + Replaces (deb) and Conflicts (rpm) are the
+# standard package-split handoff (Debian Policy 7.6.1); the metapackage itself
+# is never matched by them, so this never needs revisiting. Keep the value in
+# step with the cutover in citrusleaf/aerospike-tools and the other tool repos.
+TOOLS_SPLIT_VERSION = 13.0.3
+
 .PHONY: deb
 deb: prep
 	fpm --force \
@@ -59,7 +64,8 @@ deb: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
-		--replaces "aerospike-tools" \
+		--replaces "aerospike-tools (<< $(TOOLS_SPLIT_VERSION))" \
+		--deb-field "Breaks: aerospike-tools (<< $(TOOLS_SPLIT_VERSION))" \
 		--package $(TARGET_DIR)/$(NAME)_$(VERSION)-$(DEB_ITERATION)_$(ARCH).deb
 
 .PHONY: rpm
@@ -83,7 +89,7 @@ rpm: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
-		--conflicts "aerospike-tools" \
+		--conflicts "aerospike-tools < $(TOOLS_SPLIT_VERSION)" \
 		--package $(TARGET_DIR)/$(NAME)-$(RPM_VERSION)-$(ITERATION).$(BUILD_DISTRO).$(ARCH).rpm
 
 .PHONY: tar

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -37,14 +37,19 @@ MAC_PKG = $(TARGET_DIR)/aerospike-asbackup-$(MAC_VERSION)-$(ARCH).pkg
 .PHONY: all
 all: deb rpm tar
 
-# aerospike-tools older than TOOLS_SPLIT_VERSION is the monolithic bundle that
-# ships these same /opt/aerospike/bin paths. From TOOLS_SPLIT_VERSION on it is
-# a transitional metapackage that ships no binaries and Depends on this package
-# instead. Versioned Breaks + Replaces (deb) and Conflicts (rpm) are the
-# standard package-split handoff (Debian Policy 7.6.1); the metapackage itself
-# is never matched by them, so this never needs revisiting. Keep the value in
-# step with the cutover in citrusleaf/aerospike-tools and the other tool repos.
-TOOLS_SPLIT_VERSION = 13.0.3
+# The aerospike-tools bundle ships these same /opt/aerospike/bin paths, so
+# the two packages cannot coexist while it does. Two conflicts express that
+# without predicting the bundle's future: the versioned one covers every
+# bundle released before the bundle started declaring the virtual token (a
+# frozen fact about the past, never needs raising), and the token one covers
+# every future file-shipping bundle at any version (the bundle Provides it as
+# long as it ships binaries, and drops it if it ever stops, at which point
+# coexistence starts working with no change here). Installing either side
+# over the other refuses with a named, actionable conflict instead of a raw
+# file collision. Keep both values in step with citrusleaf/aerospike-tools
+# and the other standalone tool repos.
+TOOLS_PRE_TOKEN_BOUND = 13.0.3
+TOOLS_BUNDLE_TOKEN = aerospike-tools-binaries
 
 .PHONY: deb
 deb: prep
@@ -64,8 +69,8 @@ deb: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
-		--replaces "aerospike-tools (<< $(TOOLS_SPLIT_VERSION))" \
-		--deb-field "Breaks: aerospike-tools (<< $(TOOLS_SPLIT_VERSION))" \
+		--conflicts "aerospike-tools (<< $(TOOLS_PRE_TOKEN_BOUND))" \
+		--conflicts "$(TOOLS_BUNDLE_TOKEN)" \
 		--package $(TARGET_DIR)/$(NAME)_$(VERSION)-$(DEB_ITERATION)_$(ARCH).deb
 
 .PHONY: rpm
@@ -89,7 +94,8 @@ rpm: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
-		--conflicts "aerospike-tools < $(TOOLS_SPLIT_VERSION)" \
+		--conflicts "aerospike-tools < $(TOOLS_PRE_TOKEN_BOUND)" \
+		--conflicts "$(TOOLS_BUNDLE_TOKEN)" \
 		--package $(TARGET_DIR)/$(NAME)-$(RPM_VERSION)-$(ITERATION).$(BUILD_DISTRO).$(ARCH).rpm
 
 .PHONY: tar


### PR DESCRIPTION
## What this is

The `aerospike-tools` bundle ships the same `/opt/aerospike/bin` paths as this package, so installing one on a host that has the other used to die on a raw file conflict:

```
dpkg: error processing archive aerospike-asbackup_4.5.8-1ubuntu22.04_aarch64.deb (--install):
 trying to overwrite '/opt/aerospike/bin/asrestore', which is also in package aerospike-tools ...
```

The bundle stays a single self-contained package (deliberately: one-file airgap installs), so the two can never coexist on one host. This PR expresses that as named, resolvable conflicts, without predicting the bundle's future:

| relation | covers |
|---|---|
| `Conflicts: aerospike-tools (<< 13.0.3)` | every bundle released before the bundle started declaring the token below. A frozen fact about the past; never needs raising. |
| `Conflicts: aerospike-tools-binaries` | every future file-shipping bundle at any version. The bundle `Provides` this virtual token for as long as it ships binaries (citrusleaf/aerospike-tools#439); if it ever stops (metapackage or retirement, at 14 or whenever), it drops the token and coexistence starts working with **no change on this side**. |

deb `Conflicts` rather than `Breaks`+`Replaces`: coexistence is impossible while the bundle ships binaries, so there is no file handoff to mediate, and nothing unversioned ships against the real package name, so nothing here can ever block a future no-binaries `aerospike-tools`.

## What users see

- Fresh installs: unchanged.
- Bundle installed, `apt install aerospike-asbackup`: apt names the conflict and resolves it by removing the bundle (a plain `dpkg -i` refuses with `conflicts with aerospike-tools`, never `trying to overwrite`).
- Bundle installed, rpm: `dnf` names the conflict and the resolution (`--allowerasing` swaps the bundle out).
- Reverse direction (tools installed, bundle being installed) refuses just as clearly; the conflict is symmetric.

## Sequencing

All six PRs land together: aerospike/aerospike-admin#532, aerospike/aql#90, aerospike/aerospike-benchmark#160, aerospike/asconfig#133, plus the bundle-side token citrusleaf/aerospike-tools#439. Any bundle released at or above 13.0.3 MUST carry the `Provides` token (the bundle build asserts it), and this tool re-releases with the conflicts before such a bundle ships.

## Verified

On `debian:12` and `rockylinux:9` with real packages: named refusals in both directions and both formats against a pre-token bundle (12.0.0), a token bundle at 13.0.3, and a token bundle at a future 14.2.0 (proving version-independence); apt/dnf auto-resolution; and one-transaction migration through a no-binaries bundle with correct file ownership and coexistence.
