### PR TITLE
feat: alias asbackup 4.5.8 and latest on Docker Hub

### DIFF
--- a/.github/workflows/copy-tools-images-to-dockerhub.yml
+++ b/.github/workflows/copy-tools-images-to-dockerhub.yml
@@ -3,7 +3,8 @@ name: Copy aerospike-asbackup images to Docker Hub
 # Copies already-published aerospike-asbackup tags from JFrog to Docker Hub.
 # Does not build images and does not write anything back to Artifactory.
 # Tags: 4.5.8-3 (multi-arch index), 4.5.8-3-amd64 (linux/amd64),
-# 4.5.8-3-arm64 (linux/arm64).
+# 4.5.8-3-arm64 (linux/arm64). Extra dest tags 4.5.8 and latest
+# are aliases of 4.5.8-3.
 
 on:
   workflow_dispatch:
@@ -26,13 +27,13 @@ on:
         required: false
         default: true
       alias-from:
-        description: Optional source tag to copy onto extra destination tags
+        description: Source tag to copy onto extra destination tags
         required: false
-        default: ""
+        default: 4.5.8-3
       alias-tags:
-        description: Optional extra destination tags (comma-separated) based on alias-from
+        description: Extra destination tags (comma-separated) based on alias-from
         required: false
-        default: ""
+        default: 4.5.8,latest
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Default the JFrog-to-Hub copy workflow to also publish `4.5.8` and `latest`, matching [aerospike-tools](https://github.com/citrusleaf/aerospike-tools/blob/master/.github/workflows/copy-tools-images-to-dockerhub.yml).
- Those extra dest tags alias the already-published `4.5.8-3` multi-arch index; no rebuild.

## Test plan
- [ ] Dry-run dispatch with the new defaults and confirm the summary lists `4.5.8-3`, `4.5.8-3-amd64`, `4.5.8-3-arm64`, plus aliases `4.5.8` and `latest` from `4.5.8-3`.
- [ ] After merge, dispatch with `dry-run: false` and verify Docker Hub has `aerospike/aerospike-asbackup:latest` (and `:4.5.8`) pointing at the same digest as `:4.5.8-3`.