### PR TITLE
TOOLS-3137 - Drop support for Debian 11

### DIFF
--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -66,41 +66,6 @@ function build_aws_sdk_cpp() {
   popd; popd
 }
 
-function install_deps_debian11() {
-  rm -rf /var/lib/apt/lists/*
-  apt-get clean
-  apt-get update -o Acquire::Retries=5
-  apt-get -y install $BUILD_DEPS_DEBIAN $FPM_DEPS_DEBIAN
-  gem install fpm -v 1.17.0
-}
-
-function compile_deps_debian11() {
-  pushd /opt
-
-  git clone https://github.com/libuv/libuv
-  pushd libuv
-  git checkout v1.43.0
-  sh autogen.sh
-  ./configure
-  make_parallel
-  make install
-  popd
-
-  git clone https://github.com/curl/curl.git
-  pushd curl
-  git checkout curl-7_81_0
-  git submodule update --init --recursive
-  mkdir build
-  cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_LIBDIR=lib -DBUILD_SHARED_LIBS=OFF -DBUILD_CURL_EXE=OFF
-  make_parallel -C build
-  pushd build
-  make install
-  popd
-  popd
-
-  build_aws_sdk_cpp
-}
-
 function install_deps_debian12() {
   rm -rf /var/lib/apt/lists/*
   apt-get clean

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -206,7 +206,6 @@ jobs:
           - el9
           - el10
           - amzn2023
-          - debian11
           - debian12
           - debian13
           - ubuntu22.04
@@ -218,7 +217,6 @@ jobs:
         matrix.distro == 'el9' && 'redhat/ubi9:9.6' ||
         matrix.distro == 'el10' && 'redhat/ubi10:10.0' ||
         matrix.distro == 'amzn2023' && 'amazonlinux:2023.9.20251208.0' ||
-        matrix.distro == 'debian11' && 'debian:bullseye-20251208' ||
         matrix.distro == 'debian12' && 'debian:bookworm-20230411' ||
         matrix.distro == 'debian13' && 'debian:trixie-20251020' ||
         matrix.distro == 'ubuntu22.04' && 'ubuntu:jammy-20231004' ||
@@ -724,7 +722,6 @@ jobs:
           - el9
           - el10
           - amzn2023
-          - debian11
           - debian12
           - debian13
           - ubuntu22.04
@@ -736,7 +733,6 @@ jobs:
         matrix.distro == 'el9' && 'redhat/ubi9:9.6' ||
         matrix.distro == 'el10' && 'redhat/ubi10:10.0' ||
         matrix.distro == 'amzn2023' && 'amazonlinux:2023.9.20251208.0' ||
-        matrix.distro == 'debian11' && 'debian:bullseye-20251208' ||
         matrix.distro == 'debian12' && 'debian:bookworm-20230411' ||
         matrix.distro == 'debian13' && 'debian:trixie-20251020' ||
         matrix.distro == 'ubuntu22.04' && 'ubuntu:jammy-20231004' ||


### PR DESCRIPTION
## Why

[TOOLS-3137](https://aerospike.atlassian.net/browse/TOOLS-3137) - "(TOOLS) Remove support for Debian 11":

> After August 31 2026, remove Debian 11 builds from the tools package and all the individual tools.

Debian 11 (bullseye) reached LTS end-of-life on **2026-08-31**, and its `bullseye-security` `Release` file expired on **2026-09-07**. `apt-get update` now fails inside the pinned `debian:bullseye-20251208` container, so every `debian11` job in **Build and Release** dies at *Install prereqs*, before checkout:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired (invalid since 1d 6h 55min 24s). Updates for this repository will not be applied.
/__w/_temp/b518dda2-84cd-4f38-9744-91baf5ea899b.sh: line 12: git: command not found
##[error]Process completed with exit code 127.
```

Representative failure (aql): https://github.com/aerospike/aql/actions/runs/34309755577

Keeping the jobs alive was considered and rejected: pinning `Acquire::Check-Valid-Until=false` gets past the expiry check, but the bullseye pool is already being purged, and a Debian 11 artifact built after EOL would ship against a base that receives no further security updates.

## What changed

- `.github/workflows/build-and-release.yml` - drop `debian11` from the `build-artifacts` and `test-install-linux-and-execute` matrices and remove its container image mapping.
- `.github/bin/install_deps.sh` - remove `install_deps_debian11` and `compile_deps_debian11`.

## Not in this PR

- `.github/bin/os_version.sh` still maps the `bullseye` codename. That is generic host detection rather than matrix config, and the `buster` mapping was likewise left in place when Debian 10 was dropped.
- The `apt-get update && apt-get install ...` one-liner in *Install prereqs* still masks apt failures under `set -e` (bash exempts `&&` lists), which is why the job reported a confusing `git: command not found` instead of the apt error. Worth splitting, but out of scope here.

## Verification

- Both matrices go from 10 distros to 9; no `debian11` entry remains in either.
- Workflow YAML parses.
- `bash -n` clean on every touched shell script.

## Related

Debian 11 removal is already complete everywhere else: TOOLS-3134 (ACT), TOOLS-3135 (ASMT), TOOLS-3136 (ASVALIDATION), CLIENT-3881 (C/C++), CLIENT-3882 (Python), CLIENT-3883 (Node.js), AER-6854, REL-3931, REL-3932, DOCS-3794, DOCS-3901, QE-581, QE-592, and the NEW download listings. TOOLS-3137 is the last open ticket.

Companion PRs on the same branch name (`TOOLS-3137-drop-debian11`) in: aql, aerospike-admin, aerospike-tools-backup, aerospike-benchmark, asconfig, aerospike-tools.


[TOOLS-3137]: https://aerospike.atlassian.net/browse/TOOLS-3137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ